### PR TITLE
Fix: Add missing mission.save() in handleTokenMinted mapping

### DIFF
--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -103,7 +103,7 @@ export function handleTokenMinted(event: TokenMinted): void {
 
     missionFungibleToken.save();
     missionMetadata.save();
-
+    mission.save();
     user.save();
   }
 }


### PR DESCRIPTION
## Description
When the `handleTokenMinted` function is called and the `activityType` is `ActivityType.MISSION`, we are creating a new mission entity. This PR adds a missing `mission.save()` to the bottom of this mapping.

### Fixed
- [add missing mission.save() in handleTokenMinted()](https://github.com/open-format/subgraph/commit/4a1016b2ea5a929b197505db9c96e81299903f9b)