### PR TITLE
Feature: Add XP Rewarded to Mission entity

### DIFF
--- a/.changeset/moody-poets-swim.md
+++ b/.changeset/moody-poets-swim.md
@@ -1,0 +1,5 @@
+---
+"@openformat/subgraph": patch
+---
+
+- Add XP Rewarded to Mission entity

--- a/schema.graphql
+++ b/schema.graphql
@@ -163,6 +163,7 @@ type Mission @entity {
   metadata: MissionMetadata
   star: Star
   user: User!
+  xp_rewarded: BigInt!
   badges: [BadgeToken!]!
   tokens: [MissionFungibleToken!] @derivedFrom(field: "mission")
   createdAt: BigInt!

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -89,6 +89,7 @@ export function handleTokenMinted(event: TokenMinted): void {
       event.params.id,
       event.params.token
     );
+    mission.xp_rewarded = event.params.amount;
 
     missionFungibleToken.amount_rewarded = event.params.amount;
     missionFungibleToken.mission = mission.id;

--- a/src/helpers/loadOrCreate.ts
+++ b/src/helpers/loadOrCreate.ts
@@ -18,6 +18,7 @@ import {
   User,
 } from "../../generated/schema";
 import {ActionId, BadgeId, MissionId, TokenBalanceId} from "./idTemplates";
+import {Zero} from "./numbers";
 
 export function loadOrCreateStar(
   appAddress: Address,
@@ -178,6 +179,7 @@ export function loadOrCreateMission(
 
   if (!_Mission) {
     _Mission = new Mission(id);
+    _Mission.xp_rewarded = Zero;
     _Mission.createdAt = event.block.timestamp;
     _Mission.createdAtBlock = event.block.number;
     _Mission.badges = [];


### PR DESCRIPTION
## Description
This PR updates the `Mission` entity and the `handleTokenMinted` mapping to log the XP amount when it is rewarded in a mission.

### Added
- Added `xp_rewarded` field to the Mission entity in the schema.

### Updated
- The `handleTokenMinted` function now sets the `xp_rewarded` field in the mission entity.
- The `loadOrCreateMission` function now initialises the `xp_rewarded` field to 0 as the default value.