### PR TITLE
Fix: Save users in mission

### DIFF
--- a/.changeset/tough-falcons-tell.md
+++ b/.changeset/tough-falcons-tell.md
@@ -1,0 +1,5 @@
+---
+"@openformat/subgraph": patch
+---
+
+Save users in all handlers in RewardsFacet

--- a/schema.graphql
+++ b/schema.graphql
@@ -148,7 +148,7 @@ type Mission @entity {
   id: ID!
   metadata: MissionMetadata
   app: App
-  user: User!
+  user: User
   xp_rewarded: BigInt!
   badges: [BadgeToken!]!
   tokens: [MissionFungibleToken!] @derivedFrom(field: "mission")

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -149,6 +149,7 @@ export function handleTokenTransferred(event: TokenTransferred): void {
 
   mission.save();
   starStats.save();
+  user.save();
 }
 export function handleBadgeMinted(event: BadgeMinted): void {
   let mission = loadOrCreateMission(
@@ -201,6 +202,7 @@ export function handleBadgeMinted(event: BadgeMinted): void {
   starStats.save();
   missionMetadata.save();
   mission.save();
+  user.save();
 }
 export function handleBadgeTransferred(event: BadgeTransferred): void {
   let mission = loadOrCreateMission(
@@ -232,4 +234,5 @@ export function handleBadgeTransferred(event: BadgeTransferred): void {
 
   missionMetadata.save();
   mission.save();
+  user.save();
 }


### PR DESCRIPTION
### Description
In the SDK, we always use multicall to issue rewards in the RewardsFacet, and always reward XP together with a mission. Initially, when I developed the subgraph handlers, I implemented user.save() only during XP rewards. However, with the new API, it is now possible to reward Badges without XP. This means that if a user who receives a Badge is not already registered in the subgraph, the subgraph will return the user as null.

### Added
- [allow user to be null in Mission](https://github.com/open-format/subgraph/commit/39200ce0dfd08b2542c32fd7ae57e4e09506ddb2)
- [add user.save() to all handlers in RewardsFacet](https://github.com/open-format/subgraph/commit/c6da540b2f9427bd128d9fbdbdfd8e2b8465ebe1)