### PR TITLE
Added tests using matchstick library

### DIFF
--- a/.changeset/cuddly-trains-provide.md
+++ b/.changeset/cuddly-trains-provide.md
@@ -1,0 +1,5 @@
+---
+"@openformat/subgraph": patch
+---
+
+Added test using matchstick library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    container: node:20-bookworm
     name: Execute Tests
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Run Tests on PR ceation and Subsequent Commits
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    container: node:20-bookworm
+    name: Execute Tests
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+            git config --global url."https://github.com/".insteadOf
+            ssh://git@github.com/
+      - name: Generate subgraph
+        run: yarn prepare:arbitrum-sepolia
+      - name: Generate code
+        run: yarn gen:arbitrum-sepolia
+      # Run tests
+      - name: Run tests
+        run: yarn run test

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ typings/
 # yarn
 .yarn
 .pnp*
+
+tests/.bin/

--- a/matchstick.yaml
+++ b/matchstick.yaml
@@ -1,0 +1,3 @@
+#testsFolder: path/to/tests
+#libsFolder: path/to/libs
+manifestPath: ./subgraph.arbitrum-sepolia.yaml

--- a/networks/local.json
+++ b/networks/local.json
@@ -1,7 +1,7 @@
 {
   "network": "mainnet",
-  "accessKey": {
-    "address": "0x44b6317365fb117c540dccfd29348f94d5bbffdc",
-    "startBlock": 0
+  "AppFactory": {
+    "startBlock": 3,
+    "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,15 +38,18 @@
 
     "deploy:arbitrum-sepolia": "dotenv cross-var -- graph deploy open-format-arbitrum-sepolia --version-label %ALCHEMY_SUBGRAPH_VERSION_ARBITRUM_SEPOLIA% --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key %ALCHEMY_DEPLOY_KEY% --ipfs https://ipfs.satsuma.xyz subgraph.arbitrum-sepolia.yaml",
     "build": "graph build",
-    "auth": "graph auth https://api.thegraph.com/deploy/"
+    "auth": "graph auth https://api.thegraph.com/deploy/",
+
+    "test": "graph test -v 0.6.0 --logs"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
-    "@graphprotocol/graph-cli": "^0.45.2",
-    "@graphprotocol/graph-ts": "^0.29.3",
+    "@graphprotocol/graph-cli": "^0.71.0",
+    "@graphprotocol/graph-ts": "^0.35.1",
     "cross-var": "^1.1.0",
     "dotenv-cli": "^7.3.0",
+    "matchstick-as": "^0.6.0",
     "mustache": "^4.2.0"
   },
   "packageManager": "yarn@1.22.1"

--- a/tests/AppFactory/AppFactory.test.ts
+++ b/tests/AppFactory/AppFactory.test.ts
@@ -1,0 +1,25 @@
+import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore } from "matchstick-as/assembly/index"
+import { newCreatedAppEvent, newCreatedERC20FactoryEvent } from "../utils";
+import { APPSTATS_ENTITY_TYPE, APP_ENTITY_TYPE, APP_ID, APP_NAME, STATS_ENTITY_TYPE, TOKEN_ID, TOKEN_NAME, TOKEN_SYMBOL, USER_ENTITY_TYPE, USER_ID } from "../fixtures";
+import { handleCreated as apphandleCreated } from "../../src/AppFactory";
+
+describe("AppFactory tests", () => {
+    afterEach(() => {
+      clearStore()
+    })
+    
+    test("Create app", () => {
+        const event = newCreatedAppEvent(APP_ID, USER_ID, APP_NAME);
+        apphandleCreated(event);
+
+        assert.fieldEquals(APP_ENTITY_TYPE, APP_ID, "name", APP_NAME);
+        assert.fieldEquals(APP_ENTITY_TYPE, APP_ID, "owner", USER_ID);
+
+        assert.fieldEquals(APPSTATS_ENTITY_TYPE, APP_ID, "id", APP_ID);
+
+        assert.fieldEquals(USER_ENTITY_TYPE, USER_ID, "id", USER_ID);
+
+        assert.entityCount(STATS_ENTITY_TYPE, 1);
+    })
+
+});

--- a/tests/ERC20Factory/ERC20Factory.test.ts
+++ b/tests/ERC20Factory/ERC20Factory.test.ts
@@ -1,0 +1,27 @@
+import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore } from "matchstick-as/assembly/index"
+import { newCreatedAppEvent, newCreatedERC20FactoryEvent } from "../utils";
+import { APPSTATS_ENTITY_TYPE, APP_ENTITY_TYPE, APP_ID, APP_NAME, STATS_ENTITY_TYPE, TOKEN_ID, TOKEN_NAME, TOKEN_SYMBOL, USER_ENTITY_TYPE, USER_ID } from "../fixtures";
+import { ByteArray, Bytes } from "@graphprotocol/graph-ts";
+// import { handleCreated } from "../../src/facet/ERC20Factory";
+
+describe("ERC20Factory tests", () => {
+    afterEach(() => {
+      clearStore()
+    })
+    
+    test("Create token", () => {
+        const event = newCreatedERC20FactoryEvent(
+            TOKEN_ID,
+            USER_ID,
+            TOKEN_NAME,
+            TOKEN_SYMBOL,
+            18,
+            "1000",
+            Bytes.fromByteArray(ByteArray.fromUTF8("Base"))
+        );
+
+        // handleCreated(event);
+        
+    })
+
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,36 @@
+import { ByteArray, Bytes } from "@graphprotocol/graph-ts";
+
+export const APP_ENTITY_TYPE = "App";
+export const APPMETADATA_ENTITY_TYPE = "AppMetadata";
+export const APPSTATS_ENTITY_TYPE = "AppStats";
+export const ACTION_ENTITY_TYPE = "Action";
+export const ACTIONMETADATA_ENTITY_TYPE = "ActionMetadata";
+export const BADGE_ENTITY_TYPE = "Badge";
+export const BADGETOKEN_ENTITY_TYPE = "BadgeToken";
+export const COLLECTEDBADGE_ENTITY_TYPE = "CollectedBadge";
+export const CONTRACT_ENTITY_TYPE = "Contract";
+export const CONTRACTDATA_ENTITY_TYPE = "ContractData";
+export const FUNGIBLETOKENMETADATA_ENTITY_TYPE = "FungibleTokenMetadata";
+export const FUNGIBLETOKEN_ENTITY_TYPE = "FungibleToken";
+export const FUNGIBLETOKENBALANCE_ENTITY_TYPE = "FungibleTokenBalance";
+export const MISSIONFUNGIBLETOKEN_ENTITY_TYPE = "MissionFungibleToken";
+export const MISSIONMETADATA_ENTITY_TYPE = "MissionMetadata";
+export const MISSION_ENTITY_TYPE = "Mission";
+export const NFT_ENTITY_TYPE = "NFT";
+export const STATS_ENTITY_TYPE = "Stats";
+export const TOKEN_ENTITY_TYPE = "Token";
+export const USER_ENTITY_TYPE = "User";
+
+
+export const APP_ID = "0x483131211b3e41e0e432cb5f4d21b25e142d1f7a";
+export const APP_NAME = "TestApp";
+
+export const USER_ID = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+export const USER2_ID = "0x335fa9d1490d49fd915f268ca559181ee88515e1";
+
+export const BADGE_ID = "0x98b3a74058737378c72cf7a0eacb8f71b1db93af";
+export const BADGE_NAME = "0x98b3a74058737378c72cf7a0eacb8f71b1db93af";
+
+export const TOKEN_ID = "0x08fef47c302422cf6d63e32e6414472989cd49e8";
+export const TOKEN_NAME = "test_token_name01";
+export const TOKEN_SYMBOL = "TST_01";

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,49 @@
+import { Address, ethereum, JSONValue, Value, ipfs, json, Bytes, BigInt } from "@graphprotocol/graph-ts"
+import { newMockEvent } from "matchstick-as/assembly/index"
+import {Created as CreatedApp} from "../generated/AppFactory/AppFactory";
+import { Created as CreatedERC20FactoryFacet } from "../generated/templates/ERC20FactoryFacet/ERC20FactoryFacet";
+
+export function newCreatedAppEvent(id: string, ownerAddress: string, name: string): CreatedApp {
+    let event = newMockEvent();
+    event.parameters = new Array();
+    let idParam = new ethereum.EventParam("id", ethereum.Value.fromAddress(Address.fromString(id)));
+    let addressParam = new ethereum.EventParam("owner", ethereum.Value.fromAddress(Address.fromString(ownerAddress)));
+    let nameParam = new ethereum.EventParam("name", ethereum.Value.fromString(name));
+  
+    event.parameters.push(idParam);
+    event.parameters.push(addressParam);
+    event.parameters.push(nameParam);
+  
+    return changetype<CreatedApp>(event);
+  }
+
+  export function newCreatedERC20FactoryEvent(
+    id: string,
+    creator: string,
+    name: string,
+    symbol: string,
+    decimals: i32,
+    supply: string,
+    implementationId: Bytes
+): CreatedERC20FactoryFacet {
+    let event = newMockEvent();
+    event.parameters = new Array();
+    let idParam = new ethereum.EventParam("id", ethereum.Value.fromAddress(Address.fromString(id)));
+    let creatorParam = new ethereum.EventParam("creator", ethereum.Value.fromAddress(Address.fromString(creator)));
+    let nameParam = new ethereum.EventParam("name", ethereum.Value.fromString(name));
+    let symbolParam = new ethereum.EventParam("symbol", ethereum.Value.fromString(symbol));
+    let decimalsParam = new ethereum.EventParam("decimals", ethereum.Value.fromI32(decimals));
+    let supplyParam = new ethereum.EventParam("supply", ethereum.Value.fromUnsignedBigInt(BigInt.fromString(supply)));
+    let implParam = new ethereum.EventParam("implementationId", ethereum.Value.fromString("Base"));
+
+    event.parameters.push(idParam);
+    event.parameters.push(creatorParam);
+    event.parameters.push(nameParam);
+    event.parameters.push(symbolParam);
+    event.parameters.push(decimalsParam);
+    event.parameters.push(supplyParam);
+    event.parameters.push(implParam);
+    
+    return changetype<CreatedERC20FactoryFacet>(event);
+  }
+  


### PR DESCRIPTION
## Added tests and github actions

## Description

This PR adds tests using matchstick library. Right now there are only 2 tests because I am hitting an error when importing Opengraph event handlers.

Also added a Github action to run tests when a PR is created.

Upgraded the `graph-cli` and `graph-ts` to latest versions.

## Testing

In order to test:
- `yarn install` will install matchstick library and upgrade graph tooling.
- `yarn prepare:arbitrum-sepolia` will generate the subgraph file.
- `yarn gen:arbitrum-sepolia` will generate subgraph code.
- `yarn run test` will download matchstick and run tests.
