### PR TITLE
[Feature] Removed AppStats and Stats entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -40,7 +40,6 @@ type App @entity {
   owner: User!
   xpToken: FungibleToken
   badges: [Badge!] @derivedFrom(field: "app")
-  stats: AppStats!
   badgeCount: BigInt!
   badgesAwarded: BigInt!
   createdAt: BigInt!
@@ -155,24 +154,4 @@ type Mission @entity {
   tokens: [MissionFungibleToken!] @derivedFrom(field: "mission")
   createdAt: BigInt!
   createdAtBlock: BigInt!
-}
-
-type AppStats @entity {
-  id: ID!
-  app: App!
-  uniqueUsers: [User!]
-  uniqueUsersCount: BigInt!
-  totalXPAwarded: BigInt!
-  totalActionsComplete: BigInt!
-  totalMissionsComplete: BigInt!
-  totalBadgesAwarded: BigInt!
-  createdAt: BigInt!
-  createdAtBlock: BigInt!
-  updatedAt: BigInt!
-  updatedAtBlock: BigInt!
-}
-
-type Stats @entity {
-  id: ID!
-  uniqueUsers: BigInt!
 }

--- a/src/AppFactory.ts
+++ b/src/AppFactory.ts
@@ -8,7 +8,6 @@ import {
 import {
   Zero,
   loadOrCreateApp,
-  loadOrCreateAppStats,
   loadOrCreateUser,
 } from "./helpers";
 
@@ -22,16 +21,12 @@ export function handleCreated(event: Created): void {
 
   let app = loadOrCreateApp(event.params.id, event);
   let user = loadOrCreateUser(event.params.owner, event);
-  let appStats = loadOrCreateAppStats(event.params.id, event);
 
   app.owner = user.id;
   app.name = event.params.name;
   app.badgeCount = Zero;
   app.badgesAwarded = Zero;
-  app.stats = appStats.id;
-  appStats.app = app.id;
 
-  appStats.save();
   app.save();
   user.save();
 }

--- a/src/helpers/loadOrCreate.ts
+++ b/src/helpers/loadOrCreate.ts
@@ -3,7 +3,6 @@ import {
   Action,
   ActionMetadata,
   App,
-  AppStats,
   Badge,
   BadgeToken,
   FungibleToken,
@@ -12,7 +11,6 @@ import {
   Mission,
   MissionFungibleToken,
   MissionMetadata,
-  Stats,
   User,
 } from "../../generated/schema";
 import {ActionId, BadgeId, MissionId, TokenBalanceId} from "./idTemplates";
@@ -88,33 +86,11 @@ export function loadOrCreateUser(
     _User = new User(id);
     _User.createdAt = event.block.timestamp;
     _User.createdAtBlock = event.block.number;
-
-    const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-    if (_User.id != ZERO_ADDRESS) {
-      let stats = loadOrCreateStats();
-      stats.uniqueUsers = stats.uniqueUsers.plus(BigInt.fromI32(1));
-      stats.save();
-    }
   }
+    _User.updatedAt = event.block.timestamp;
+    _User.updatedAtBlock = event.block.number;
 
-  _User.updatedAt = event.block.timestamp;
-  _User.updatedAtBlock = event.block.number;
-
-  return _User as User;
-}
-
-export function loadOrCreateStats(): Stats {
-  let stats = Stats.load("STATS_SINGLETON");
-
-  // If the Stats entity doesn't exist, create it and set uniqueUsers to 0.
-  if (!stats) {
-    stats = new Stats("STATS_SINGLETON");
-    stats.uniqueUsers = BigInt.fromI32(0);
-    stats.save();
-  }
-
-  return stats as Stats;
+    return _User as User;
 }
 
 export function loadOrCreateActionMetadata(
@@ -276,28 +252,4 @@ export function loadOrCreateFungibleTokenBalance(
   _FungibleTokenBalance.updatedAtBlock = event.block.number;
 
   return _FungibleTokenBalance as FungibleTokenBalance;
-}
-
-export function loadOrCreateAppStats(
-  appId: Address,
-  event: ethereum.Event
-): AppStats {
-  const id = appId.toHex();
-  let _AppStats = AppStats.load(id);
-
-  if (!_AppStats) {
-    _AppStats = new AppStats(id);
-    _AppStats.createdAt = event.block.timestamp;
-    _AppStats.createdAtBlock = event.block.number;
-    _AppStats.totalActionsComplete = BigInt.fromI32(0);
-    _AppStats.totalMissionsComplete = BigInt.fromI32(0);
-    _AppStats.totalBadgesAwarded = BigInt.fromI32(0);
-    _AppStats.totalXPAwarded = BigInt.fromI32(0);
-    _AppStats.uniqueUsersCount = BigInt.fromI32(0);
-  }
-
-  _AppStats.updatedAt = event.block.timestamp;
-  _AppStats.updatedAtBlock = event.block.number;
-
-  return _AppStats as AppStats;
 }

--- a/tests/AppFactory.test.ts
+++ b/tests/AppFactory.test.ts
@@ -1,6 +1,6 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, logDataSources } from "matchstick-as/assembly/index"
-import { Param, ParamType, createApp, newEvent } from "./utils";
-import { TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "./fixtures";
+import { assert, clearStore, test, describe, afterEach } from "matchstick-as/assembly/index";
+import { createApp } from "./utils";
+import { TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "./fixtures";
 
 describe("AppFactory tests", () => {
     afterEach(() => {
@@ -13,11 +13,8 @@ describe("AppFactory tests", () => {
         assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "name", TEST_APP_NAME);
         assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "owner", TEST_USER_ID);
 
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "id", TEST_APP_ID);
-
         assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER_ID, "id", TEST_USER_ID);
 
-        assert.entityCount(TEST_STATS_ENTITY_TYPE, 1);
 
         assert.dataSourceCount('ERC721FactoryFacet', 1);
         assert.dataSourceCount('ERC20FactoryFacet', 1);

--- a/tests/ERC20Base.test.ts
+++ b/tests/ERC20Base.test.ts
@@ -1,6 +1,6 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, dataSourceMock, beforeEach } from "matchstick-as/assembly/index"
-import { Param, ParamType, createApp, createERC20Token, getTestFungibleToken, newEvent, transferERC20, updateERC20ContractURI } from "./utils";
-import { TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_FUNGIBLETOKENBALANCE_ENTITY_TYPE, TEST_FUNGIBLETOKENMETADATA_ENTITY_TYPE, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "./fixtures";
+import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock, beforeEach } from "matchstick-as/assembly/index";
+import { getTestFungibleToken, transferERC20, updateERC20ContractURI } from "./utils";
+import { TEST_FUNGIBLETOKENBALANCE_ENTITY_TYPE, TEST_FUNGIBLETOKENMETADATA_ENTITY_TYPE, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE } from "./fixtures";
 import { Address, BigInt, DataSourceContext, Value, ethereum } from "@graphprotocol/graph-ts";
 import { TokenBalanceId } from "../src/helpers";
 

--- a/tests/ERC721Base.test.ts
+++ b/tests/ERC721Base.test.ts
@@ -1,8 +1,8 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, dataSourceMock, beforeEach } from "matchstick-as/assembly/index"
-import { Param, ParamType, batchMintedERC721, createApp, createERC20Token, createERC721Token, getTestBadgeTokenEntity, getTestFungibleToken, mintedERC721, newEvent, transferERC20, transferERC721, updateERC20ContractURI } from "./utils";
-import { TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_BADGE_ENTITY_TYPE, TEST_BADGE_ID, TEST_FUNGIBLETOKENBALANCE_ENTITY_TYPE, TEST_FUNGIBLETOKENMETADATA_ENTITY_TYPE, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "./fixtures";
+import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock, beforeEach } from "matchstick-as/assembly/index";
+import { batchMintedERC721, createApp, createERC721Token, getTestBadgeTokenEntity, mintedERC721, transferERC721 } from "./utils";
+import { TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_BADGE_ENTITY_TYPE, TEST_BADGE_ID, TEST_TOKEN_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE } from "./fixtures";
 import { Address, BigInt, DataSourceContext, Value, ethereum } from "@graphprotocol/graph-ts";
-import { BadgeId, One, TokenBalanceId } from "../src/helpers";
+import { BadgeId, One } from "../src/helpers";
 
 describe("ERC721Base tests", () => {
     afterEach(() => {

--- a/tests/ERC721LazyMint.test.ts
+++ b/tests/ERC721LazyMint.test.ts
@@ -1,8 +1,8 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, dataSourceMock, beforeEach } from "matchstick-as/assembly/index"
-import { Param, ParamType, batchMintedERC721, batchMintedERC721LazyMint, createApp, createERC20Token, createERC721LazyMintToken, createERC721Token, getTestBadgeTokenEntity, getTestFungibleToken, mintLazyMint, mintedERC721, mintedERC721LazyMint, newEvent, transferERC20, transferERC721, transferERC721LazyMint, updateERC20ContractURI } from "./utils";
-import { TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_BADGE_ENTITY_TYPE, TEST_BADGE_ID, TEST_FUNGIBLETOKENBALANCE_ENTITY_TYPE, TEST_FUNGIBLETOKENMETADATA_ENTITY_TYPE, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "./fixtures";
+import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock, beforeEach } from "matchstick-as/assembly/index";
+import { batchMintedERC721LazyMint, createApp, createERC721LazyMintToken, getTestBadgeTokenEntity, mintLazyMint, mintedERC721LazyMint, transferERC721LazyMint } from "./utils";
+import { TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_BADGE_ENTITY_TYPE, TEST_BADGE_ID, TEST_TOKEN_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE } from "./fixtures";
 import { Address, BigInt, DataSourceContext, Value, ethereum } from "@graphprotocol/graph-ts";
-import { BadgeId, One, TokenBalanceId } from "../src/helpers";
+import { BadgeId, One } from "../src/helpers";
 
 describe("ERC721LazyMint tests", () => {
     afterEach(() => {

--- a/tests/facet/ERC20Factory.test.ts
+++ b/tests/facet/ERC20Factory.test.ts
@@ -1,6 +1,6 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, dataSourceMock } from "matchstick-as/assembly/index"
-import { Param, ParamType, createApp, createERC20Token, newEvent } from "../utils";
-import { TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_USER2_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
+import { assert, clearStore, test, describe, afterEach, dataSourceMock } from "matchstick-as/assembly/index";
+import { createApp, createERC20Token } from "../utils";
+import { TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_USER2_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
 
 describe("ERC20Factory tests", () => {
     afterEach(() => {

--- a/tests/facet/ERC721Factory.test.ts
+++ b/tests/facet/ERC721Factory.test.ts
@@ -1,6 +1,6 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, dataSourceMock } from "matchstick-as/assembly/index"
-import { Param, ParamType, createApp, createERC721LazyMintToken, createERC721Token, newEvent } from "../utils";
-import { TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_BADGE_ENTITY_TYPE, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_NFT_ENTITY_TYPE, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_IMPLEMENTATIONID_LAZYMINT, TEST_TOKEN_NAME, TEST_TOKEN_ROYALTYBPS, TEST_TOKEN_ROYALTYRECIPIENT, TEST_TOKEN_SYMBOL, TEST_USER2_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
+import { assert, clearStore, test, describe, afterEach, dataSourceMock } from "matchstick-as/assembly/index";
+import { createApp, createERC721LazyMintToken, createERC721Token } from "../utils";
+import { TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_NAME, TEST_TOKEN_ROYALTYBPS, TEST_TOKEN_ROYALTYRECIPIENT, TEST_TOKEN_SYMBOL, TEST_USER2_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
 
 describe("ERC721Factory tests", () => {
     afterEach(() => {

--- a/tests/facet/RewardsFacet.test.ts
+++ b/tests/facet/RewardsFacet.test.ts
@@ -1,6 +1,6 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, dataSourceMock } from "matchstick-as/assembly/index"
-import { Param, ParamType, createApp, createBadge, createERC20Token, getTestBadgeTokenEntity, badgeMintedLegacy, mintERC20TokenAction, mintERC20TokenMission, newEvent, transferBadge, transferERC20TokenMission, badgeMinted, erc721Minted, updatedBaseURI } from "../utils";
-import { TEST_ACTIONMETADATA_ENTITY_TYPE, TEST_ACTION_ENTITY_TYPE, TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, TEST_MISSIONMETADATA_ENTITY_TYPE, TEST_MISSION_ENTITY_TYPE, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_MINTED_ACTION, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
+import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock } from "matchstick-as/assembly/index";
+import { createApp, createBadge, createERC20Token, getTestBadgeTokenEntity, badgeMintedLegacy, mintERC20TokenAction, mintERC20TokenMission, transferBadge, transferERC20TokenMission, badgeMinted, erc721Minted, updatedBaseURI } from "../utils";
+import { TEST_ACTIONMETADATA_ENTITY_TYPE, TEST_ACTION_ENTITY_TYPE, TEST_APP_ID, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, TEST_MISSIONMETADATA_ENTITY_TYPE, TEST_MISSION_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
 import { ActionId, BadgeId, MissionId, loadBadgeToken } from "../../src/helpers";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Mission } from "../../generated/schema";
@@ -33,11 +33,6 @@ describe("RewardsFacet tests", () => {
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "id", actionId);
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "name", TEST_TOKEN_MINTED_ACTION_ID);
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "URI", TEST_TOKEN_MINTED_URI);
-
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalXPAwarded", event.params.amount.toString());
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalActionsComplete", "1");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalBadgesAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "uniqueUsersCount", "1");
     })
 
     test("Token minted MISSION", () => {
@@ -68,12 +63,6 @@ describe("RewardsFacet tests", () => {
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "mission", missionId);
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "token", event.params.token.toHex());
-
-        // TODO: Mint token mission does not change app stats
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalXPAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalActionsComplete", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalBadgesAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "uniqueUsersCount", "0");
     })
 
     test("Token transferred MISSION", () => {
@@ -107,13 +96,6 @@ describe("RewardsFacet tests", () => {
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "mission", missionId);
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "token", event.params.token.toHex());
-
-        // TODO: Transfer token does not change totalXPAwarded or uniqueUsersCount
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalXPAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalActionsComplete", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalBadgesAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "uniqueUsersCount", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalMissionsComplete", "1");
     })
 
     // older reward contract had a different event signature
@@ -153,12 +135,6 @@ describe("RewardsFacet tests", () => {
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, id, "metadataURI", event.params.uri);
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, id, "owner", event.params.to.toHex());
         }
-
-        // TODO: Mint token mission does not change uniqueUsersCount
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalXPAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalActionsComplete", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalBadgesAwarded", event.params.quantity.toString());
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "uniqueUsersCount", "0");
     })
 
     test("Badge token minted", () => {
@@ -205,12 +181,6 @@ describe("RewardsFacet tests", () => {
                 assert.assertNotNull(badgeToken)
             }
         }
-
-        // TODO: Mint token mission does not change uniqueUsersCount
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalXPAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalActionsComplete", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalBadgesAwarded", event.params.quantity.toString());
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "uniqueUsersCount", "0");
     })
 
     test("ERC721 token minted", () => {
@@ -249,12 +219,6 @@ describe("RewardsFacet tests", () => {
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, id, "metadataURI", event.params.uri);
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, id, "owner", event.params.to.toHex());
         }
-
-        // TODO: Mint token mission does not change uniqueUsersCount
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalXPAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalActionsComplete", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalBadgesAwarded", event.params.quantity.toString());
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "uniqueUsersCount", "0");
     })
 
     test("Badge transfer", () => {
@@ -288,11 +252,6 @@ describe("RewardsFacet tests", () => {
         assert.assertTrue(mission!.badges != null, "Mission has badges");
         assert.assertTrue(mission!.badges.length == 1, "Mission badges has length = 1");
         assert.assertTrue(mission!.badges.at(0) == badgeToken.id, "Badge is ok");
-
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalXPAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalActionsComplete", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "totalBadgesAwarded", "0");
-        assert.fieldEquals(TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ID, "uniqueUsersCount", "0");
     })
 
 });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,6 +1,5 @@
 export const TEST_APP_ENTITY_TYPE = "App";
 export const TEST_APPMETADATA_ENTITY_TYPE = "AppMetadata";
-export const TEST_APPSTATS_ENTITY_TYPE = "AppStats";
 export const TEST_ACTION_ENTITY_TYPE = "Action";
 export const TEST_ACTIONMETADATA_ENTITY_TYPE = "ActionMetadata";
 export const TEST_BADGE_ENTITY_TYPE = "Badge";
@@ -15,7 +14,6 @@ export const TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE = "MissionFungibleToken";
 export const TEST_MISSIONMETADATA_ENTITY_TYPE = "MissionMetadata";
 export const TEST_MISSION_ENTITY_TYPE = "Mission";
 export const TEST_NFT_ENTITY_TYPE = "NFT";
-export const TEST_STATS_ENTITY_TYPE = "Stats";
 export const TEST_TOKEN_ENTITY_TYPE = "Token";
 export const TEST_USER_ENTITY_TYPE = "User";
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,13 +1,10 @@
-import { Address, ethereum, JSONValue, Value, ipfs, json, Bytes, BigInt, DataSourceContext } from "@graphprotocol/graph-ts"
-import { dataSourceMock, newMockEvent } from "matchstick-as/assembly/index"
-import {Created as CreatedApp} from "../generated/AppFactory/AppFactory";
-import { Created as CreatedERC20FactoryFacet } from "../generated/templates/ERC20FactoryFacet/ERC20FactoryFacet";
-import { Created as CreatedERC721FactoryFacet } from "../generated/templates/ERC721FactoryFacet/ERC721Factory";
-import { Created as ERC20Created} from "../generated/templates/ERC20FactoryFacet/ERC20FactoryFacet";
+import { Address, ethereum, Value, Bytes, BigInt, DataSourceContext } from "@graphprotocol/graph-ts";
+import { dataSourceMock, newMockEvent } from "matchstick-as/assembly/index";
+import { Created as ERC20Created } from "../generated/templates/ERC20FactoryFacet/ERC20FactoryFacet";
 import { Created as ERC721Created } from "../generated/templates/ERC721FactoryFacet/ERC721Factory";
 import { BadgeMinted1, BadgeMinted, ERC721Minted, BadgeTransferred, TokenMinted, TokenTransferred } from "../generated/templates/RewardsFacet/RewardsFacet";
 import { Created as AppCreated } from "../generated/AppFactory/AppFactory";
-import { TEST_ACTION_ENTITY_TYPE, TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_BADGETOKEN_ID, TEST_BADGE_ID, TEST_FUNGIBLETOKEN_ENTITY_TYPE, TEST_STATS_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BADGE, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_IMPLEMENTATIONID_LAZYMINT, TEST_TOKEN_MINTED_ACTION, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_ROYALTYBPS, TEST_TOKEN_ROYALTYRECIPIENT, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "./fixtures";
+import { TEST_APP_ID, TEST_APP_NAME, TEST_BADGETOKEN_ID, TEST_BADGE_ID, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BADGE, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_IMPLEMENTATIONID_LAZYMINT, TEST_TOKEN_MINTED_ACTION, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_ROYALTYBPS, TEST_TOKEN_ROYALTYRECIPIENT, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ID } from "./fixtures";
 import { handleCreated as erc20handleCreated } from "../src/facet/ERC20Factory";
 import { handleCreated as appHandleCreated } from "../src/AppFactory";
 import { handleCreated as erc721handleCreated } from "../src/facet/ERC721Factory";


### PR DESCRIPTION
## Summary

Removed entities AppStats and Stats because the data they store is already captured in metrics subgraph.

## Related Issue/Bounty

OF-265
