### PR TITLE
[Fix] Updated handlers to save Users and delete BadgeTokens

### DIFF
--- a/src/ERC721Badge.ts
+++ b/src/ERC721Badge.ts
@@ -83,6 +83,7 @@ export function handleBatchMinted(event: BatchMinted): void {
   }
 
   badge.save();
+  user.save();
 }
 
 export function handleTransfer(event: Transfer): void {
@@ -90,10 +91,11 @@ export function handleTransfer(event: Transfer): void {
   let user = loadOrCreateUser(event.params.to, event);
   if (Badge) {
     if (event.params.to == ZERO_ADDRESS) {
-      store.remove("Badge", Badge.id);
+      store.remove("BadgeToken", Badge.id);
     } else {
       Badge.owner = user.id;
       Badge.save();
+      user.save();
     }
   }
 }

--- a/src/ERC721Base.ts
+++ b/src/ERC721Base.ts
@@ -77,6 +77,7 @@ export function handleBatchMinted(event: BatchMinted): void {
   }
 
   badge.save();
+  user.save();
 }
 
 export function handleTransfer(event: Transfer): void {
@@ -85,10 +86,11 @@ export function handleTransfer(event: Transfer): void {
   if (Badge) {
     if (event.params.to == ZERO_ADDRESS) {
       //@TODO is burntSupply the correct name?
-      store.remove("Badge", Badge.id);
+      store.remove("BadgeToken", Badge.id);
     } else {
       Badge.owner = user.id;
       Badge.save();
+      user.save();
     }
   }
 }

--- a/src/ERC721LazyMint.ts
+++ b/src/ERC721LazyMint.ts
@@ -64,6 +64,7 @@ export function handleBatchMinted(event: BatchMinted): void {
 
   Badge.totalAwarded = totalSupplyBeforeMint.plus(event.params.quantity);
   Badge.save();
+  user.save();
 }
 
 export function handleLazyMint(event: TokensLazyMinted): void {
@@ -74,12 +75,14 @@ export function handleLazyMint(event: TokensLazyMinted): void {
 
 export function handleTransfer(event: Transfer): void {
   let Badge = loadBadgeToken(event.address, event.params.tokenId);
+  let user = loadOrCreateUser(event.params.to, event);
   if (Badge) {
     if (event.params.to == ZERO_ADDRESS) {
-      store.remove("Badge", Badge.id);
+      store.remove("BadgeToken", Badge.id);
     } else {
       Badge.owner = event.params.to.toHex();
       Badge.save();
+      user.save();
     }
   }
 }

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -47,6 +47,7 @@ export function handleTokenMinted(event: TokenMinted): void {
 
     actionMetadata.save();
     action.save();
+    user.save();
   } else {
     let mission = loadOrCreateMission(
       event.transaction.hash,

--- a/tests/ERC721Badge.test.ts
+++ b/tests/ERC721Badge.test.ts
@@ -1,10 +1,10 @@
-import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock, beforeEach } from "matchstick-as/assembly/index";
-import { batchMintedERC721, createApp, createERC721Token, getTestBadgeTokenEntity, mintedERC721, transferERC721 } from "./utils";
+import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock, beforeEach, logDataSources, logStore } from "matchstick-as/assembly/index";
+import { batchMintedBadge, batchMintedERC721, createApp, createERC721Token, getTestBadgeTokenEntity, mintedBadge, mintedERC721, transferERC721, transferERC721Badge } from "./utils";
 import { TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_BADGE_ENTITY_TYPE, TEST_BADGE_ID, TEST_TOKEN_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE } from "./fixtures";
-import { Address, BigInt, DataSourceContext, Value, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, DataSourceContext, Value, ethereum, store } from "@graphprotocol/graph-ts";
 import { BadgeId, One } from "../src/helpers";
 
-describe("ERC721Base tests", () => {
+describe("ERC721Badge tests", () => {
     afterEach(() => {
       clearStore();
       dataSourceMock.resetValues();
@@ -15,8 +15,8 @@ describe("ERC721Base tests", () => {
         createERC721Token();
 
         let context = new DataSourceContext()
-        context.set('ERC721Contract', Value.fromString(TEST_TOKEN_ID))
-        dataSourceMock.setReturnValues(TEST_TOKEN_ID, 'ERC721Contract', context)
+        context.set('ERC721ContractBadge', Value.fromString(TEST_TOKEN_ID))
+        dataSourceMock.setReturnValues(TEST_TOKEN_ID, 'ERC721ContractBadge', context)
     })
     
     test("Token batch minted", () => {
@@ -25,7 +25,7 @@ describe("ERC721Base tests", () => {
             .withArgs([ ])
             .returns([ ethereum.Value.fromUnsignedBigInt(BigInt.fromString(TEST_TOKEN_TOTAL_SUPPLY)) ]);
 
-        const event = batchMintedERC721();
+        const event = batchMintedBadge();
 
         assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID);
 
@@ -38,7 +38,6 @@ describe("ERC721Base tests", () => {
 
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "id", badgeTokenId);
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "owner", event.params.to.toHex());
-            assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "metadataURI", event.params.baseURI);
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "tokenId", tokenId.toString());
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "badge", event.address.toHex());
         }
@@ -58,53 +57,20 @@ describe("ERC721Base tests", () => {
         );
     })
 
-    test("Token minted existing", () => {
-
-        createMockedFunction(Address.fromString(TEST_TOKEN_ID), "nextTokenIdToMint", "nextTokenIdToMint():(uint256)")
-            .withArgs([ ])
-            .returns([ ethereum.Value.fromUnsignedBigInt(BigInt.fromString(TEST_BADGETOKEN_ID).plus(One)) ]);
-
-        const badgeToken = getTestBadgeTokenEntity(
-            Address.fromString(TEST_TOKEN_ID), 
-            BigInt.fromString(TEST_BADGETOKEN_ID),
-            TEST_USER2_ID,
-            TEST_TOKEN_MINTED_URI
-        );
-        badgeToken.save();
-    
-        const event = mintedERC721();
-
-        // Receiver of minted token
-        assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID);
-
-        assert.entityCount(TEST_BADGETOKEN_ENTITY_TYPE, 1); // Used existing badge token
-        assert.entityCount(TEST_BADGE_ENTITY_TYPE, 1); // Used existing badge
-        
-        // TODO: Should this be a counter instead
-        assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "badgesAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
-
-        // Badge Token
-        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "id", badgeToken.id);
-        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "owner", event.params.to.toHex());
-        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "metadataURI", event.params.tokenURI);
-        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "badge", event.address.toHex());
-    })
-
-    test("Token minted new", () => {
+    test("Token minted", () => {
         
         createMockedFunction(Address.fromString(TEST_TOKEN_ID), "nextTokenIdToMint", "nextTokenIdToMint():(uint256)")
             .withArgs([ ])
             .returns([ ethereum.Value.fromUnsignedBigInt(BigInt.fromString(TEST_BADGETOKEN_ID).plus(One)) ]);
 
-        const event = mintedERC721();
+        const event = mintedBadge();
 
         // Receiver of minted token
         assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID);
 
-        assert.entityCount(TEST_BADGETOKEN_ENTITY_TYPE, 1); // Used existing badge token
-        assert.entityCount(TEST_BADGE_ENTITY_TYPE, 1); // Used existing badge
+        assert.entityCount(TEST_BADGETOKEN_ENTITY_TYPE, 1);
+        assert.entityCount(TEST_BADGE_ENTITY_TYPE, 1);
         
-        // TODO: Should this be a counter instead
         assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "badgesAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
 
         const badgeTokenId = BadgeId(Address.fromString(TEST_TOKEN_ID), BigInt.fromString(TEST_BADGETOKEN_ID).toHex());
@@ -113,46 +79,45 @@ describe("ERC721Base tests", () => {
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "id", badgeTokenId);
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "owner", event.params.to.toHex());
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "tokenId", TEST_BADGETOKEN_ID);
-        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "metadataURI", event.params.tokenURI);
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "badge", event.address.toHex());
     })
 
     test("Badge transfer", () => {
 
-        const badgeToken = getTestBadgeTokenEntity(
-            Address.fromString(TEST_BADGE_ID), 
-            BigInt.fromString(TEST_BADGETOKEN_ID),
-            TEST_USER2_ID,
-            TEST_TOKEN_MINTED_URI
-        );
-        badgeToken.save();
+        createMockedFunction(Address.fromString(TEST_TOKEN_ID), "nextTokenIdToMint", "nextTokenIdToMint():(uint256)")
+            .withArgs([ ])
+            .returns([ ethereum.Value.fromUnsignedBigInt(BigInt.fromString(TEST_BADGETOKEN_ID).plus(One)) ]);
+        const badgeTokenId = BadgeId(Address.fromString(TEST_TOKEN_ID), BigInt.fromString(TEST_BADGETOKEN_ID).toHex());
 
-        const event = transferERC721(TEST_USER3_ID);
+        mintedBadge(); // Create BadgeToken
+
+        const event = transferERC721Badge(TEST_USER3_ID);
         
         // User data
         assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID);
 
+        // logStore();
+        
         // Badge data
-        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "id", badgeToken.id);
-        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "owner", event.params.to.toHex());
+        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "id", badgeTokenId);
+        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "owner", event.params.to.toHex());
     })
 
     test("Badge burned", () => {
 
-        const badgeToken = getTestBadgeTokenEntity(
-            Address.fromString(TEST_BADGE_ID), 
-            BigInt.fromString(TEST_BADGETOKEN_ID),
-            TEST_USER2_ID,
-            TEST_TOKEN_MINTED_URI
-        );
-        badgeToken.save();
+        createMockedFunction(Address.fromString(TEST_TOKEN_ID), "nextTokenIdToMint", "nextTokenIdToMint():(uint256)")
+            .withArgs([ ])
+            .returns([ ethereum.Value.fromUnsignedBigInt(BigInt.fromString(TEST_BADGETOKEN_ID).plus(One)) ]);
+        const badgeTokenId = BadgeId(Address.fromString(TEST_TOKEN_ID), BigInt.fromString(TEST_BADGETOKEN_ID).toHex());
 
-        transferERC721("0x0000000000000000000000000000000000000000");
+        mintedBadge(); // Create BadgeToken
+
+        transferERC721Badge("0x0000000000000000000000000000000000000000");
 
         assert.notInStore(TEST_USER_ENTITY_TYPE, "0x0000000000000000000000000000000000000000");
 
         // BadgeToken data
-        assert.notInStore(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id);
+        assert.notInStore(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId);
     })
 
 });

--- a/tests/ERC721LazyMint.test.ts
+++ b/tests/ERC721LazyMint.test.ts
@@ -28,8 +28,7 @@ describe("ERC721LazyMint tests", () => {
 
         const event = batchMintedERC721LazyMint();
 
-        // TODO: User is not saved
-        // assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID);
+        assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID);
 
         assert.entityCount(TEST_BADGETOKEN_ENTITY_TYPE, event.params.quantity.toI32());
         assert.entityCount(TEST_BADGE_ENTITY_TYPE, 1);
@@ -107,6 +106,7 @@ describe("ERC721LazyMint tests", () => {
         // Badge Token
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "id", badgeTokenId);
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "owner", event.params.to.toHex());
+        assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "tokenId", TEST_BADGETOKEN_ID);
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "metadataURI", event.params.tokenURI);
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeTokenId, "badge", event.address.toHex());
     })
@@ -137,6 +137,9 @@ describe("ERC721LazyMint tests", () => {
 
         const event = transferERC721LazyMint(TEST_USER3_ID);
 
+        // User data
+        assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID);
+
         // Badge data
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "id", badgeToken.id);
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "owner", event.params.to.toHex());
@@ -152,11 +155,12 @@ describe("ERC721LazyMint tests", () => {
         );
         badgeToken.save();
 
-        // TODO: Error here trying to remove Badge with BadgeToken id
-        // transferERC721LazyMint("0x0000000000000000000000000000000000000000");
+        transferERC721LazyMint("0x0000000000000000000000000000000000000000");
+
+        assert.notInStore(TEST_USER_ENTITY_TYPE, "0x0000000000000000000000000000000000000000");
 
         // BadgeToken data
-        // assert.notInStore(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id);
+        assert.notInStore(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id);
     })
 
 });

--- a/tests/facet/ERC721Factory.test.ts
+++ b/tests/facet/ERC721Factory.test.ts
@@ -29,7 +29,6 @@ describe("ERC721Factory tests", () => {
         assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "app", TEST_APP_ID);
         assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAwarded", "0");
         assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAvailable", "0");
-        // TODO: no owner for NFT?
     })
 
     test("Create token LazyMint", () => {
@@ -53,6 +52,5 @@ describe("ERC721Factory tests", () => {
         assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "app", TEST_APP_ID);
         assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAwarded", "0");
         assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAvailable", "0");
-        // TODO: no owner for NFT?
     })
 });

--- a/tests/facet/RewardsFacet.test.ts
+++ b/tests/facet/RewardsFacet.test.ts
@@ -19,8 +19,7 @@ describe("RewardsFacet tests", () => {
         // Users data
         assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER_ID, "id", TEST_USER_ID); // App user
         assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER2_ID, "id", TEST_USER2_ID); // Token user
-        // TODO: User is not saved if new
-        // assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID); // Token minted user
+        assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER3_ID, "id", TEST_USER3_ID); // Token minted user
 
         const actionId = ActionId(event.transaction.hash, event.logIndex);
 
@@ -66,8 +65,6 @@ describe("RewardsFacet tests", () => {
     })
 
     test("Token transferred MISSION", () => {
-        // TODO: Are token transferred events only triggered for missions?
-
         createApp();
         createERC20Token();
         const event = transferERC20TokenMission();

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -14,6 +14,8 @@ import { BadgeToken, FungibleToken } from "../generated/schema";
 import { ContractURIUpdated as ERC20ContractURIUpdated, Transfer as ERC20Transfer } from "../generated/templates/ERC20Base/ERC20Base";
 import { handleContractURIUpdated, handleTransfer as handleTransferERC20 } from "../src/ERC20Base";
 import { BatchMinted, Minted, Transfer as ERC721Transfer } from "../generated/templates/ERC721Base/ERC721Base";
+import { BatchMinted as BatchMintedBadge, Minted as MintedBadge, Transfer as TransferBadge } from "../generated/templates/ERC721Badge/ERC721Badge";
+import { handleBatchMinted as handleBatchMintedBadge, handleMinted as handleMintedBadge, handleTransfer as handleTransferBadge } from "../src/ERC721Badge";
 import { handleBatchMinted, handleMinted, handleTransfer as handleTransferERC721 } from "../src/ERC721Base";
 import { TokensLazyMinted, Minted as MintedLazyMint, Transfer as TransferERC721LazyMint, BatchMinted as BatchMintedLazyMint } from "../generated/templates/ERC721LazyMint/ERC721LazyMint";
 import { handleLazyMint, handleTransfer as handleTransferERC721LazyMint, handleMinted as handleMintedLazyMint, handleBatchMinted as handleBatchMintedLazyMint } from "../src/ERC721LazyMint";
@@ -326,6 +328,44 @@ export function transferERC721(to: string): ERC721Transfer {
   event.address = Address.fromString(TEST_BADGE_ID);
   // Event handler
   handleTransferERC721(event);
+
+  return event;
+}
+
+export function mintedBadge(): MintedBadge {
+  const event = newEvent<MintedBadge>([
+      new Param("to", ParamType.ADDRESS, TEST_USER3_ID),
+      new Param("tokenURI", ParamType.STRING, "uri://abc"),
+  ]);
+  event.address = Address.fromString(TEST_TOKEN_ID);
+  // Event handler
+  handleMintedBadge(event);
+
+  return event;
+}
+
+export function batchMintedBadge(): BatchMintedBadge {
+  const event = newEvent<BatchMintedBadge>([
+      new Param("to", ParamType.ADDRESS, TEST_USER3_ID),
+      new Param("quantity", ParamType.BIG_INT, "2"),
+      new Param("baseURI", ParamType.STRING, "uri://abc"),
+  ]);
+  event.address = Address.fromString(TEST_TOKEN_ID);
+  // Event handler
+  handleBatchMintedBadge(event);
+
+  return event;
+}
+
+export function transferERC721Badge(to: string): TransferBadge {
+  const event = newEvent<TransferBadge>([
+      new Param("from", ParamType.ADDRESS, TEST_USER_ID),
+      new Param("to", ParamType.ADDRESS, to),
+      new Param("tokenId", ParamType.BIG_INT, TEST_BADGETOKEN_ID),
+  ]);
+  event.address = Address.fromString(TEST_TOKEN_ID);
+  // Event handler
+  handleTransferBadge(event);
 
   return event;
 }


### PR DESCRIPTION
## Summary

Fixed problems in handlers where User entity was not saved and BadgeToken was not deleted.

## Related Issue/Bounty

OF-266

## Testing

Added tests for `ERC721Badge` handlers.

