### PR TITLE
Feature/of 438 uri is not being indexed when rewarding badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `FungibleToken.app` field (#124)
+
+### Fixed
+
+- Bug where `MissionMetadata.URI` field was being indexed incorrectly (#70)

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -224,7 +224,7 @@ function handleERC721MintedEvent(
     missionBadges.push(missionBadge.id);
   }
 
-  missionMetadata.URI = badgeMetadataURI ? badgeMetadataURI : params.data.toString()
+  missionMetadata.URI = params.data.toString();
   missionMetadata.name = params.activityId.toString();
 
   mission.user = user.id;

--- a/tests/facet/RewardsFacet.test.ts
+++ b/tests/facet/RewardsFacet.test.ts
@@ -1,6 +1,6 @@
 import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock, beforeEach } from "matchstick-as/assembly/index";
 import { createApp, createBadge, createERC20Token, getTestBadgeTokenEntity, badgeMintedLegacy, mintERC20TokenAction, mintERC20TokenMission, transferBadge, transferERC20TokenMission, badgeMinted, erc721Minted, updatedBaseURI } from "../utils";
-import { TEST_ACTIONMETADATA_ENTITY_TYPE, TEST_ACTION_ENTITY_TYPE, TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, TEST_APP_ID, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, TEST_MISSIONMETADATA_ENTITY_TYPE, TEST_MISSION_ENTITY_TYPE, TEST_TOKEN_DECIMALS, TEST_TOKEN_ID, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
+import { TEST_ACTIONMETADATA_ENTITY_TYPE, TEST_ACTION_ENTITY_TYPE, TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, TEST_APP_ID, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, TEST_MISSIONMETADATA_ENTITY_TYPE, TEST_MISSION_ENTITY_TYPE, TEST_TOKEN_DECIMALS, TEST_TOKEN_ID, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_MISSION_URI, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
 import { ActionId, AppFungibleTokenId, BadgeId, MissionId, ZERO_ADDRESS, loadBadgeToken } from "../../src/helpers";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Mission } from "../../generated/schema";
@@ -31,7 +31,7 @@ describe("RewardsFacet tests", () => {
 
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "id", actionId);
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "name", TEST_TOKEN_MINTED_ACTION_ID);
-        assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "URI", TEST_TOKEN_MINTED_URI);
+        assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
     })
 
     test("Token minted MISSION", () => {
@@ -56,7 +56,7 @@ describe("RewardsFacet tests", () => {
 
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "id", missionFungibleTokenId);
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
@@ -87,7 +87,7 @@ describe("RewardsFacet tests", () => {
 
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "id", missionFungibleTokenId);
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
@@ -132,7 +132,7 @@ describe("RewardsFacet tests", () => {
 
             assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
             assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-            assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+            assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
             assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "id", missionFungibleTokenId);
             assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
@@ -164,7 +164,7 @@ describe("RewardsFacet tests", () => {
 
             assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
             assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-            assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+            assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
             assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "id", missionFungibleTokenId);
             assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
@@ -201,7 +201,7 @@ describe("RewardsFacet tests", () => {
 
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
         const quantity = event.params.quantity;
         for (let i = 0; i < quantity.toI32(); i++) {
@@ -241,7 +241,7 @@ describe("RewardsFacet tests", () => {
 
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
         const quantity = event.params.quantity;
         for (let i = 0; i < quantity.toI32(); i++) {
@@ -285,7 +285,7 @@ describe("RewardsFacet tests", () => {
 
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
         const quantity = event.params.quantity;
         for (let i = 0; i < quantity.toI32(); i++) {
@@ -325,7 +325,7 @@ describe("RewardsFacet tests", () => {
 
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "id", missionId);
         assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "name", TEST_TOKEN_MINTED_MISSION_ID);
-        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_URI);
+        assert.fieldEquals(TEST_MISSIONMETADATA_ENTITY_TYPE, missionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
 
         const mission = Mission.load(missionId);
         assert.assertTrue(mission!.badges != null, "Mission has badges");

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -48,6 +48,7 @@ export const TEST_TOKEN_MINTED_ACTION = "ACTION";
 export const TEST_TOKEN_MINTED_ACTION_ID = "ACTION_ID";
 export const TEST_TOKEN_MINTED_MISSION = "MISSION";
 export const TEST_TOKEN_MINTED_MISSION_ID = "MISSION_ID";
+export const TEST_TOKEN_MINTED_MISSION_URI = "ipfs://Qmam9tnUCBjBBDtXUaZKQ3svoyjDALV8jo4wj9WWHQvuN5"
 export const TEST_TOKEN_MINTED_URI = "ipfs://abcd123456";
 
 export const TEST_CHARGE_ID = "CHARGE_ID";

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -4,7 +4,7 @@ import { Created as ERC20Created } from "../generated/templates/ERC20FactoryFace
 import { Created as ERC721Created } from "../generated/templates/ERC721FactoryFacet/ERC721Factory";
 import { BadgeMinted1, BadgeMinted, ERC721Minted, BadgeTransferred, TokenMinted, TokenTransferred } from "../generated/templates/RewardsFacet/RewardsFacet";
 import { Created as AppCreated } from "../generated/AppFactory/AppFactory";
-import { TEST_APP_ID, TEST_APP_NAME, TEST_BADGETOKEN_ID, TEST_BADGE_ID, TEST_CHARGE_ID, TEST_CHARGE_TYPE, TEST_ONE_ETHER, TEST_TOKEN_DECIMALS, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BADGE, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_IMPLEMENTATIONID_LAZYMINT, TEST_TOKEN_MINTED_ACTION, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_ROYALTYBPS, TEST_TOKEN_ROYALTYRECIPIENT, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ID } from "./fixtures";
+import { TEST_APP_ID, TEST_APP_NAME, TEST_BADGETOKEN_ID, TEST_BADGE_ID, TEST_CHARGE_ID, TEST_CHARGE_TYPE, TEST_ONE_ETHER, TEST_TOKEN_DECIMALS, TEST_TOKEN_ID, TEST_TOKEN_IMPLEMENTATIONID_BADGE, TEST_TOKEN_IMPLEMENTATIONID_BASE, TEST_TOKEN_IMPLEMENTATIONID_LAZYMINT, TEST_TOKEN_MINTED_ACTION, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_MISSION_URI, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_ROYALTYBPS, TEST_TOKEN_ROYALTYRECIPIENT, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ID } from "./fixtures";
 import { handleCreated as erc20handleCreated } from "../src/facet/ERC20Factory";
 import { handleCreated as appHandleCreated } from "../src/AppFactory";
 import { handleCreated as erc721handleCreated } from "../src/facet/ERC721Factory";
@@ -160,7 +160,7 @@ export function mintERC20TokenAction(): TokenMinted {
       new Param("amount", ParamType.BIG_INT, "2"),
       new Param("id", ParamType.BYTES, TEST_TOKEN_MINTED_ACTION_ID),
       new Param("activityType", ParamType.BYTES, TEST_TOKEN_MINTED_ACTION),
-      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_URI),
+      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_MISSION_URI),
   ]);
   // Event handler
   handleTokenMinted(tokenMintedEvent);
@@ -175,7 +175,7 @@ export function mintERC20TokenMission(): TokenMinted {
       new Param("amount", ParamType.BIG_INT, "2"),
       new Param("id", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION_ID),
       new Param("activityType", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION),
-      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_URI),
+      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_MISSION_URI),
   ]);
   // Event handler
   handleTokenMinted(tokenMintedEvent);
@@ -190,7 +190,7 @@ export function transferERC20TokenMission(): TokenTransferred {
       new Param("amount", ParamType.BIG_INT, "2"),
       new Param("id", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION_ID),
       new Param("activityType", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION),
-      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_URI),
+      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_MISSION_URI),
   ]);
   // Event handler
   handleTokenTransferred(event);
@@ -205,7 +205,7 @@ export function badgeMinted(): BadgeMinted {
     new Param("to", ParamType.ADDRESS, TEST_USER3_ID),
     new Param("activityId", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION_ID),
     new Param("activityType", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION),
-    new Param("data", ParamType.BYTES, ""),
+    new Param("data", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION_URI),
   ]);
   // Event handler
   handleBadgeMinted(event)
@@ -220,7 +220,7 @@ export function erc721Minted(): ERC721Minted {
     new Param("to", ParamType.ADDRESS, TEST_USER3_ID),
     new Param("id", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION_ID),
     new Param("activityType", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION),
-    new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_URI),
+    new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_MISSION_URI),
   ]);
   // Event handler
   handleERC721Minted(event);
@@ -235,7 +235,7 @@ export function badgeMintedLegacy(): BadgeMinted1 {
     new Param("to", ParamType.ADDRESS, TEST_USER3_ID),
     new Param("id", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION_ID),
     new Param("activityType", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION),
-    new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_URI),
+    new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_MISSION_URI),
   ]);
   // Event handler
   handleBadgeMintedLegacy(event);
@@ -265,7 +265,7 @@ export function transferBadge(): BadgeTransferred {
       new Param("tokenId", ParamType.BIG_INT, TEST_BADGETOKEN_ID),
       new Param("id", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION_ID),
       new Param("activityType", ParamType.BYTES, TEST_TOKEN_MINTED_MISSION),
-      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_URI),
+      new Param("uri", ParamType.STRING, TEST_TOKEN_MINTED_MISSION_URI),
   ]);
   // Event handler
   handleBadgeTransferred(event);


### PR DESCRIPTION
- Fixes bug where mission metadata URI was incorrectly defaulting to token URI rather using the `event.params.data`
- Updates tests to use a different URI for mission metadata URI field.
