### PR TITLE
Deploy to base

### DIFF
--- a/networks/base-sepolia.json
+++ b/networks/base-sepolia.json
@@ -1,0 +1,7 @@
+{
+  "network": "base-sepolia",
+  "AppFactory": {
+    "address": "0x2d6f1620b263Ce71862Fa95f6fEAbB6A366478cC",
+    "startBlock": 18394476
+  }
+}

--- a/networks/base.json
+++ b/networks/base.json
@@ -1,0 +1,7 @@
+{
+  "network": "base",
+  "AppFactory": {
+    "address": "0x2d6f1620b263Ce71862Fa95f6fEAbB6A366478cC",
+    "startBlock": 22715950
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "prepare:mumbai": "mustache networks/mumbai.json subgraph.template.yaml subgraph.mumbai.yaml",
     "prepare:polygon": "mustache networks/polygon.json subgraph.template.yaml subgraph.polygon.yaml",
     "prepare:local": "mustache networks/local.json subgraph.template.yaml subgraph.local.yaml",
+    "prepare:base-sepolia": "mustache networks/base-sepolia.json subgraph.template.yaml subgraph.base-sepolia.yaml",
+    "prepare:base": "mustache networks/base.json subgraph.template.yaml subgraph.base.yaml",
     "prepare:aurora": "mustache networks/aurora.json subgraph.template.yaml subgraph.aurora.yaml",
     "prepare:aurora-testnet": "mustache networks/aurora-testnet.json subgraph.template.yaml subgraph.aurora-testnet.yaml",
     "prepare:arbitrum-sepolia": "mustache networks/arbitrum-sepolia.json subgraph.template.yaml subgraph.arbitrum-sepolia.yaml",
@@ -21,6 +23,8 @@
 
     "gen:mumbai": "graph codegen subgraph.mumbai.yaml",
     "gen:polygon": "graph codegen subgraph.polygon.yaml",
+    "gen:base-sepolia": "graph codegen subgraph.base-sepolia.yaml",
+    "gen:base": "graph codegen subgraph.base.yaml",
     "gen:aurora": "graph codegen subgraph.aurora.yaml",
     "gen:aurora-testnet": "graph codegen subgraph.aurora-testnet.yaml",
     "gen:arbitrum-sepolia": "graph codegen subgraph.arbitrum-sepolia.yaml",
@@ -30,6 +34,8 @@
     
     "deploy:local": "graph deploy open-format-local --ipfs http://0.0.0.0:5001 --node http://0.0.0.0:8020 subgraph.local.yaml",
     "deploy:mumbai": "dotenv cross-var -- graph deploy --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% --ipfs http://%IPFS_URL% open-format/mumbai subgraph.mumbai.yaml",
+    "deploy:base-sepolia": "graph deploy --studio open-format-base-sepolia subgraph.base-sepolia.yaml",
+    "deploy:base": "graph deploy --studio open-format-base subgraph.base.yaml",
     "deploy:aurora": "graph deploy --studio open-format-aurora subgraph.aurora.yaml",
     "deploy:aurora-testnet": "graph deploy --studio open-format-aurora-testnet subgraph.aurora-testnet.yaml",
 


### PR DESCRIPTION
Deploys to base and base sepolia
- [Add base and base sepolia networks](https://github.com/open-format/subgraph/pull/73/commits/041b3fe5aedecfa05e13245b4cccf364888f5895)
- [Add base and base sepolia deploy scripts](https://github.com/open-format/subgraph/pull/73/commits/3e5286a30c7989dc190b6788d5983cdf57bce9ec)

Endpoints:
https://api.studio.thegraph.com/query/82634/open-format-base-sepolia/v0.1.0a
https://api.studio.thegraph.com/query/82634/open-format-base/v0.1.0

Note: sepolia version is `v0.1.0a` as initially deployed with base network config by accident and cannot redeploy version with the graph studio.