### PR TITLE
Fix: Update totalAwarded when minting badges

### DIFF
--- a/src/ERC721Badge.ts
+++ b/src/ERC721Badge.ts
@@ -33,10 +33,13 @@ export function handleMinted(event: Minted): void {
 
   let badgeToken = loadOrCreateBadgeToken(event.address, tokenId, event);
 
-  let badge = loadBadge(event.address);
+  let badge = loadOrCreateBadge(contractAddress, event);
+  const totalSupply = boundContract.totalSupply();
 
-  if (badge) {
-    let app = App.load(badge.app);
+  let appBadge = loadBadge(event.address);
+
+  if (appBadge) {
+    let app = App.load(appBadge.app);
     if (app) {
       app.badgesAwarded = tokenId.plus(One);
       app.save();
@@ -49,6 +52,9 @@ export function handleMinted(event: Minted): void {
   badgeToken.tokenId = tokenId;
   badgeToken.badge = event.address.toHex();
 
+  badge.totalAwarded = totalSupply;
+
+  badge.save();
   badgeToken.save();
   user.save();
 }

--- a/src/ERC721Base.ts
+++ b/src/ERC721Base.ts
@@ -23,12 +23,15 @@ export function handleMinted(event: Minted): void {
   const boundContract = ERC721BaseContract.bind(contractAddress);
   const tokenId = boundContract.nextTokenIdToMint().minus(One);
 
+  let badge = loadOrCreateBadge(contractAddress, event);
+  const totalSupply = boundContract.totalSupply();
+
   let badgeToken = loadOrCreateBadgeToken(event.address, tokenId, event);
 
-  let badge = loadBadge(event.address);
+  let appBadge = loadBadge(event.address);
 
-  if (badge) {
-    let app = App.load(badge.app);
+  if (appBadge) {
+    let app = App.load(appBadge.app);
     if (app) {
       app.badgesAwarded = tokenId.plus(One);
       app.save();
@@ -42,6 +45,9 @@ export function handleMinted(event: Minted): void {
   badgeToken.tokenId = tokenId;
   badgeToken.badge = event.address.toHex();
 
+  badge.totalAwarded = totalSupply;
+
+  badge.save();
   badgeToken.save();
   user.save();
 }

--- a/tests/ERC721Badge.test.ts
+++ b/tests/ERC721Badge.test.ts
@@ -73,6 +73,9 @@ describe("ERC721Badge tests", () => {
         
         assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "badgesAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
 
+        // Badge
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
+
         const badgeTokenId = BadgeId(Address.fromString(TEST_TOKEN_ID), BigInt.fromString(TEST_BADGETOKEN_ID).toHex());
 
         // Badge Token

--- a/tests/ERC721Base.test.ts
+++ b/tests/ERC721Base.test.ts
@@ -83,6 +83,9 @@ describe("ERC721Base tests", () => {
         // TODO: Should this be a counter instead
         assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "badgesAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
 
+        // Badge
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
+
         // Badge Token
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "id", badgeToken.id);
         assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, badgeToken.id, "owner", event.params.to.toHex());
@@ -106,6 +109,9 @@ describe("ERC721Base tests", () => {
         
         // TODO: Should this be a counter instead
         assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "badgesAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
+
+        // Badge
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAwarded", BigInt.fromString(TEST_BADGETOKEN_ID).plus(One).toString());
 
         const badgeTokenId = BadgeId(Address.fromString(TEST_TOKEN_ID), BigInt.fromString(TEST_BADGETOKEN_ID).toHex());
 

--- a/tests/facet/ERC721Factory.test.ts
+++ b/tests/facet/ERC721Factory.test.ts
@@ -1,5 +1,5 @@
 import { assert, clearStore, test, describe, afterEach, dataSourceMock } from "matchstick-as/assembly/index";
-import { createApp, createERC721LazyMintToken, createERC721Token } from "../utils";
+import { createApp, createBadge, createERC721LazyMintToken, createERC721Token } from "../utils";
 import { TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, TEST_TOKEN_NAME, TEST_TOKEN_ROYALTYBPS, TEST_TOKEN_ROYALTYRECIPIENT, TEST_TOKEN_SYMBOL, TEST_USER2_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
 
 describe("ERC721Factory tests", () => {
@@ -14,6 +14,29 @@ describe("ERC721Factory tests", () => {
 
         assert.dataSourceCount('ERC721Base', 1);
         // TODO: Check ERC721Base has context with key: "ERC721Contract" and value: event.params.id.toHex()
+
+        // Users data
+        assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER_ID, "id", TEST_USER_ID); // App user
+        assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER2_ID, "id", TEST_USER2_ID); // Token user
+        // App new data
+        assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "badgeCount", "1"); // badgeCount
+        // Fungible token data
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "id", TEST_TOKEN_ID);
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "name", TEST_TOKEN_NAME);
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "symbol", TEST_TOKEN_SYMBOL);
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "royaltyBps", TEST_TOKEN_ROYALTYBPS.toString());
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "royaltyRecipient", TEST_TOKEN_ROYALTYRECIPIENT);
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "app", TEST_APP_ID);
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAwarded", "0");
+        assert.fieldEquals(TEST_BADGE_ENTITY_TYPE, TEST_TOKEN_ID, "totalAvailable", "0");
+    })
+
+    test("Create token Badge", () => {
+        createApp();
+        createBadge();
+
+        assert.dataSourceCount('ERC721Badge', 1);
+        // TODO: Check ERC721Badge has context with key: "ERC721Contract" and value: event.params.id.toHex()
 
         // Users data
         assert.fieldEquals(TEST_USER_ENTITY_TYPE, TEST_USER_ID, "id", TEST_USER_ID); // App user


### PR DESCRIPTION
## Description

This PR fixes a problem where Badges `totalAwarded` attribute was not updated when minting a single BadgeToken. This update affects both `Badge` and `ERC721` types of badges.

## Type of Change

Please check the boxes that apply to your pull request:

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Tests have been updated.
