### PR TITLE
Feature/of 328 replace missionaction with one universal entity in the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `Reward` entity ([#76](https://github.com/open-format/subgraph/pull/76))
+
+### Deprecated
+- `Mission` and `Action` entities ([#76](https://github.com/open-format/subgraph/pull/76))
+
 
 ## [v0.1.0] - 2024-11-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openformat/subgraph",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "reinstall": "rm -rf .pnp* && yarn",
     "clean": "rm -rf build/ generated/",

--- a/schema.graphql
+++ b/schema.graphql
@@ -101,12 +101,6 @@ type BadgeToken @entity {
   updatedAtBlock: BigInt!
 }
 
-type CollectedBadge @entity {
-  id: ID!
-  user: User!
-  metadataURI: String!
-}
-
 type Badge @entity {
   id: ID!
   name: String!

--- a/schema.graphql
+++ b/schema.graphql
@@ -124,19 +124,6 @@ type Badge @entity {
   updatedAtBlock: BigInt!
 }
 
-# @TODO - Implement IPFS data types
-# type BadgeMetadata @entity {
-#   id: ID!
-#   name: String!
-#   description: String!
-#   image: String!
-#   external_url: String!
-#   animation_url: String!
-#   URI: String!
-#   createdAt: BigInt!
-#   createdAtBlock: BigInt!
-# }
-
 type User @entity {
   id: ID!
   tokenBalances: [FungibleTokenBalance!] @derivedFrom(field: "user")

--- a/schema.graphql
+++ b/schema.graphql
@@ -138,7 +138,7 @@ type Reward @entity (immutable: true) {
   token: FungibleToken
   tokenAmount: BigInt!
   badge: Badge
-  badges: [BadgeToken!]
+  badgeTokens: [BadgeToken!]
   badgeCount: Int!
   transactionHash: String!
   createdAt: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -147,6 +147,26 @@ type User @entity {
   updatedAtBlock: BigInt!
 }
 
+type Reward @entity (immutable: true) {
+  id: ID!
+  app: App!
+  rewardId: String!
+  rewardType: String!
+  metadataURI: String!
+  user: User!
+  token: FungibleToken
+  tokenAmount: BigInt!
+  badge: Badge
+  badges: [BadgeToken!]
+  badgeCount: Int!
+  transactionHash: String!
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+}
+
+"""
+DEPRECATED: The `Action` entity has been deprecated as please query the `Reward` entity with `rewardType: "ACTION"` instead.
+"""
 type Action @entity {
   id: ID!
   metadata: ActionMetadata
@@ -157,12 +177,18 @@ type Action @entity {
   createdAtBlock: BigInt!
 }
 
+"""
+DEPRECATED: The `ActionMetadata` entity has been deprecated as please query the `Reward` with `rewardType: "ACTION"` instead.
+"""
 type ActionMetadata @entity {
   id: ID!
   name: String
   URI: String!
 }
 
+"""
+DEPRECATED: The `MissionFungibleToken` entity has been deprecated as please query the `Reward` entity instead.
+"""
 type MissionFungibleToken @entity {
   id: ID!
   token: FungibleToken!
@@ -170,12 +196,18 @@ type MissionFungibleToken @entity {
   amount_rewarded: BigInt!
 }
 
+"""
+DEPRECATED: The `MissionMetadata` entity has been deprecated as please query the `Reward` entity with `rewardType: "MISSION"` instead.
+"""
 type MissionMetadata @entity {
   id: ID!
   name: String
   URI: String!
 }
 
+"""
+DEPRECATED: The `Mission` entity has been deprecated as please query the `Reward` entity with `rewardType: "MISSION"` instead.
+"""
 type Mission @entity {
   id: ID!
   metadata: MissionMetadata

--- a/src/facet/DEPRECATED_RewardsFacet.ts
+++ b/src/facet/DEPRECATED_RewardsFacet.ts
@@ -13,19 +13,18 @@ import {
   TokenMinted,
   TokenTransferred,
 } from "../../generated/templates/RewardsFacet/RewardsFacet";
-import { createExternalFungibleToken, loadBadgeToken } from "../helpers";
-import {
+import { 
+  loadBadgeToken,
   loadOrCreateAction,
   loadOrCreateActionMetadata,
-  loadOrCreateAppFungibleToken,
   loadOrCreateBadge,
   loadOrCreateBadgeToken,
   loadOrCreateMission,
   loadOrCreateMissionFungibleToken,
   loadOrCreateMissionMetadata,
   loadOrCreateUser,
-} from "../helpers/loadOrCreate";
-import { FungibleToken } from "../../generated/schema";
+  associateAppWithToken
+} from "../helpers";
 
 export function DEPRECATED_handleTokenMinted(event: TokenMinted): void {
   let context = dataSource.context();
@@ -277,17 +276,6 @@ export function DEPRECATED_handleBadgeTransferred(event: BadgeTransferred): void
   missionMetadata.save();
   mission.save();
   user.save();
-}
-
-function associateAppWithToken(appAddress: Address, tokenAddress: Address, event: ethereum.Event): void {
-  // Check token exists
-  let fungibleToken = FungibleToken.load(tokenAddress.toHex());
-  if (!fungibleToken) {
-    createExternalFungibleToken(tokenAddress, event);
-  }
-  // Ensure app has an association with fungibleToken
-  let appFungibleToken = loadOrCreateAppFungibleToken(appAddress, tokenAddress);
-  appFungibleToken.save();
 }
 
 export class BadgeMintedParams {

--- a/src/facet/DEPRECATED_RewardsFacet.ts
+++ b/src/facet/DEPRECATED_RewardsFacet.ts
@@ -1,0 +1,340 @@
+/*
+  All functions in this file are related to deprecated entities.
+  TODO: remove when actions/missions entities are removed from schema
+*/
+
+import { Address, BigInt, Bytes, ByteArray, dataSource, ethereum } from "@graphprotocol/graph-ts";
+import { ERC721Base as BadgeContract } from "../../generated/templates/ERC721Base/ERC721Base";
+import {
+  BadgeMinted,
+  BadgeMinted1,
+  BadgeTransferred,
+  ERC721Minted,
+  TokenMinted,
+  TokenTransferred,
+} from "../../generated/templates/RewardsFacet/RewardsFacet";
+import { createExternalFungibleToken, loadBadgeToken } from "../helpers";
+import {
+  loadOrCreateAction,
+  loadOrCreateActionMetadata,
+  loadOrCreateAppFungibleToken,
+  loadOrCreateBadge,
+  loadOrCreateBadgeToken,
+  loadOrCreateMission,
+  loadOrCreateMissionFungibleToken,
+  loadOrCreateMissionMetadata,
+  loadOrCreateUser,
+} from "../helpers/loadOrCreate";
+import { FungibleToken } from "../../generated/schema";
+
+export function DEPRECATED_handleTokenMinted(event: TokenMinted): void {
+  let context = dataSource.context();
+  let appAddress = Address.fromString(context.getString("App"));
+  let user = loadOrCreateUser(event.params.to, event);
+
+  if (event.params.activityType.toString() == "ACTION") {
+    let action = loadOrCreateAction(
+      event.transaction.hash,
+      event.logIndex,
+      event
+    );
+
+    let actionMetadata = loadOrCreateActionMetadata(
+      event.transaction.hash,
+      event.logIndex
+    );
+
+    actionMetadata.name = event.params.id.toString();
+    actionMetadata.URI = event.params.uri;
+
+    action.user = user.id;
+    action.xp_rewarded = event.params.amount;
+    action.app = appAddress.toHex();
+    action.metadata = actionMetadata.id;
+
+    actionMetadata.save();
+    action.save();
+    user.save();
+  } else {
+    let mission = loadOrCreateMission(
+      event.transaction.hash,
+      event.params.id,
+      event
+    );
+
+    let missionMetadata = loadOrCreateMissionMetadata(
+      event.transaction.hash,
+      event.params.id
+    );
+
+    let missionFungibleToken = loadOrCreateMissionFungibleToken(
+      event.transaction.hash,
+      event.params.id,
+      event.params.token
+    );
+
+    associateAppWithToken(appAddress, event.params.token, event);
+
+    // TODO: this looks like if a any token is rewarded as part of a mission it will wrongly count as xp
+    mission.xp_rewarded = event.params.amount;
+
+    missionFungibleToken.amount_rewarded = event.params.amount;
+    missionFungibleToken.mission = mission.id;
+    missionFungibleToken.token = event.params.token.toHex();
+
+    missionMetadata.name = event.params.id.toString();
+    missionMetadata.URI = event.params.uri;
+
+    mission.user = user.id;
+    mission.app = appAddress.toHex();
+    mission.metadata = missionMetadata.id;
+
+    missionFungibleToken.save();
+    missionMetadata.save();
+    mission.save();
+    user.save();
+  }
+}
+export function DEPRECATED_handleTokenTransferred(event: TokenTransferred): void {
+  let context = dataSource.context();
+  let appAddress = Address.fromString(context.getString("App"));
+  let mission = loadOrCreateMission(
+    event.transaction.hash,
+    event.params.id,
+    event
+  );
+
+  let missionMetadata = loadOrCreateMissionMetadata(
+    event.transaction.hash,
+    event.params.id
+  );
+
+  let missionFungibleToken = loadOrCreateMissionFungibleToken(
+    event.transaction.hash,
+    event.params.id,
+    event.params.token
+  );
+
+  associateAppWithToken(appAddress, event.params.token, event);
+
+  let user = loadOrCreateUser(event.params.to, event);
+
+  missionFungibleToken.amount_rewarded = event.params.amount;
+  missionFungibleToken.mission = mission.id;
+  missionFungibleToken.token = event.params.token.toHex();
+
+  missionMetadata.name = event.params.id.toString();
+  missionMetadata.URI = event.params.uri;
+
+  mission.user = user.id;
+  mission.app = appAddress.toHex();
+  mission.metadata = missionMetadata.id;
+
+  missionFungibleToken.save();
+  missionMetadata.save();
+
+  mission.save();
+  user.save();
+}
+
+
+// handles ERC721 tokens being rewarded with the uri being emitted from the event
+export function DEPRECATED_handleERC721Minted(event: ERC721Minted): void {
+  handleERC721MintedEvent(new BadgeMintedParams(
+    event.params.token,
+    event.params.quantity,
+    event.params.to,
+    event.params.id,
+    event.params.activityType,
+    Bytes.fromByteArray(ByteArray.fromUTF8(event.params.uri))
+  ), event)
+}
+
+// handles ERC721 tokens being rewarded with the uri being emitted from the event
+// but with the event named BadgeMinted
+export function DEPRECATED_handleBadgeMintedLegacy(event: BadgeMinted1): void {
+  handleERC721MintedEvent(new BadgeMintedParams(
+    event.params.token,
+    event.params.quantity,
+    event.params.to,
+    event.params.id,
+    event.params.activityType,
+    Bytes.fromByteArray(ByteArray.fromUTF8(event.params.uri))
+  ), event)
+}
+
+// handles ERC721 badge tokens being rewarded with the uri on the contract
+export function DEPRECATED_handleBadgeMinted(event: BadgeMinted): void {
+  handleERC721MintedEvent(new BadgeMintedParams(
+    event.params.token,
+    event.params.quantity,
+    event.params.to,
+    event.params.activityId,
+    event.params.activityType,
+    event.params.data
+  ), event)
+}
+
+// takes a common param interface for erc721 minted events and indexes them
+// {
+//   token: Address;
+//   to: Address;
+//   quantity: BigInt;
+//   activityId: Bytes;
+//   activityType: Bytes;
+//   data: Bytes;
+// }
+function handleERC721MintedEvent(
+  params: BadgeMintedParams
+  , event: ethereum.Event): void {
+  let context = dataSource.context();
+  let appAddress = Address.fromString(context.getString("App"));
+
+  let mission = loadOrCreateMission(
+    event.transaction.hash,
+    params.activityId,
+    event
+  );
+
+  let boundContract = BadgeContract.bind(params.token);
+
+  let missionMetadata = loadOrCreateMissionMetadata(
+    event.transaction.hash,
+    params.activityId
+  );
+  let user = loadOrCreateUser(params.to, event);
+  let badge = loadOrCreateBadge(params.token, event);
+  let badgeMetadataURI = badge.metadataURI
+  let totalSupply = boundContract.totalSupply();
+  let quantity = params.quantity;
+  let missionBadges = mission.badges;
+
+  //@DEV currently, if the same Badge gets rewarded in more that one mission in a single transactions
+  //we can't calculate the tokenId.
+
+  for (let i = 0; i < quantity.toI32(); i++) {
+    let tokenId = totalSupply.minus(quantity).plus(BigInt.fromI32(i));
+    let missionBadge = loadOrCreateBadgeToken(
+      params.token,
+      tokenId,
+      event
+    );
+
+    missionBadge.badge = params.token.toHex();
+    missionBadge.owner = user.id;
+    missionBadge.metadataURI = badgeMetadataURI ? null : params.data.toString();
+
+    missionBadge.save();
+
+    missionBadges.push(missionBadge.id);
+  }
+
+  missionMetadata.URI = params.data.toString();
+  missionMetadata.name = params.activityId.toString();
+
+  mission.user = user.id;
+  mission.app = appAddress.toHex();
+  mission.metadata = missionMetadata.id;
+  mission.badges = missionBadges;
+
+  missionMetadata.save();
+  mission.save();
+  user.save();
+}
+
+export function DEPRECATED_handleBadgeTransferred(event: BadgeTransferred): void {
+  let context = dataSource.context();
+  let appAddress = Address.fromString(context.getString("App"));
+
+  let mission = loadOrCreateMission(
+    event.transaction.hash,
+    event.params.id,
+    event
+  );
+
+  let missionMetadata = loadOrCreateMissionMetadata(
+    event.transaction.hash,
+    event.params.id
+  );
+
+  let missionBadge = loadBadgeToken(event.params.token, event.params.tokenId);
+
+  let user = loadOrCreateUser(event.params.to, event);
+  missionMetadata.name = event.params.id.toString();
+  missionMetadata.URI = event.params.uri;
+
+  mission.user = user.id;
+  mission.app = appAddress.toHex();
+  mission.metadata = missionMetadata.id;
+
+  let missionBadges = mission.badges;
+
+  if (missionBadges && missionBadge) {
+    missionBadges.push(missionBadge.id);
+    mission.badges = missionBadges;
+  }
+
+  missionMetadata.save();
+  mission.save();
+  user.save();
+}
+
+function associateAppWithToken(appAddress: Address, tokenAddress: Address, event: ethereum.Event): void {
+  // Check token exists
+  let fungibleToken = FungibleToken.load(tokenAddress.toHex());
+  if (!fungibleToken) {
+    createExternalFungibleToken(tokenAddress, event);
+  }
+  // Ensure app has an association with fungibleToken
+  let appFungibleToken = loadOrCreateAppFungibleToken(appAddress, tokenAddress);
+  appFungibleToken.save();
+}
+
+export class BadgeMintedParams {
+  _token: Address
+  _quantity: BigInt
+  _to: Address
+  _activityId: Bytes
+  _activityType: Bytes
+  _data: Bytes
+
+  constructor(
+    token: Address,
+    quantity: BigInt,
+    to: Address,
+    activityId: Bytes,
+    activityType: Bytes,
+    data: Bytes
+  ) {
+    this._token = token
+    this._quantity = quantity
+    this._to = to
+    this._activityId = activityId
+    this._activityType = activityType
+    this._data = data
+  }
+
+  get token(): Address {
+    return this._token;
+  }
+
+  get quantity(): BigInt {
+    return this._quantity;
+  }
+
+  get to(): Address {
+    return this._to;
+  }
+
+  get activityId(): Bytes {
+    return this._activityId;
+  }
+
+  get activityType(): Bytes {
+    return this._activityType;
+  }
+
+  get data(): Bytes {
+    return this._data;
+  }
+}

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -1,335 +1,241 @@
-import { Address, BigInt, Bytes, ByteArray, dataSource, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, dataSource } from "@graphprotocol/graph-ts";
 import { ERC721Base as BadgeContract } from "../../generated/templates/ERC721Base/ERC721Base";
 import {
   BadgeMinted,
   BadgeMinted1,
-  BadgeTransferred,
   ERC721Minted,
+  BadgeTransferred,
   TokenMinted,
   TokenTransferred,
+
 } from "../../generated/templates/RewardsFacet/RewardsFacet";
-import { createExternalFungibleToken, loadBadgeToken } from "../helpers";
 import {
-  loadOrCreateAction,
-  loadOrCreateActionMetadata,
-  loadOrCreateAppFungibleToken,
   loadOrCreateBadge,
   loadOrCreateBadgeToken,
-  loadOrCreateMission,
-  loadOrCreateMissionFungibleToken,
-  loadOrCreateMissionMetadata,
+  loadOrCreateFungibleToken,
+  loadOrCreateReward,
   loadOrCreateUser,
 } from "../helpers/loadOrCreate";
-import { FungibleToken } from "../../generated/schema";
+import { Zero } from "../helpers";
+import {
+  DEPRECATED_handleBadgeMinted,
+  DEPRECATED_handleERC721Minted,
+  DEPRECATED_handleBadgeMintedLegacy,
+  DEPRECATED_handleBadgeTransferred,
+  DEPRECATED_handleTokenMinted,
+  DEPRECATED_handleTokenTransferred
+} from "./DEPRECATED_RewardsFacet";
 
 export function handleTokenMinted(event: TokenMinted): void {
+  DEPRECATED_handleTokenMinted(event)
+
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
   let user = loadOrCreateUser(event.params.to, event);
+  let token = loadOrCreateFungibleToken(event.params.token, event)
 
-  if (event.params.activityType.toString() == "ACTION") {
-    let action = loadOrCreateAction(
-      event.transaction.hash,
-      event.logIndex,
-      event
-    );
-
-    let actionMetadata = loadOrCreateActionMetadata(
-      event.transaction.hash,
-      event.logIndex
-    );
-
-    actionMetadata.name = event.params.id.toString();
-    actionMetadata.URI = event.params.uri;
-
-    action.user = user.id;
-    action.xp_rewarded = event.params.amount;
-    action.app = appAddress.toHex();
-    action.metadata = actionMetadata.id;
-
-    actionMetadata.save();
-    action.save();
-    user.save();
-  } else {
-    let mission = loadOrCreateMission(
-      event.transaction.hash,
-      event.params.id,
-      event
-    );
-
-    let missionMetadata = loadOrCreateMissionMetadata(
-      event.transaction.hash,
-      event.params.id
-    );
-
-    let missionFungibleToken = loadOrCreateMissionFungibleToken(
-      event.transaction.hash,
-      event.params.id,
-      event.params.token
-    );
-
-    associateAppWithToken(appAddress, event.params.token, event);
-
-    // TODO: this looks like if a any token is rewarded as part of a mission it will wrongly count as xp
-    mission.xp_rewarded = event.params.amount;
-
-    missionFungibleToken.amount_rewarded = event.params.amount;
-    missionFungibleToken.mission = mission.id;
-    missionFungibleToken.token = event.params.token.toHex();
-
-    missionMetadata.name = event.params.id.toString();
-    missionMetadata.URI = event.params.uri;
-
-    mission.user = user.id;
-    mission.app = appAddress.toHex();
-    mission.metadata = missionMetadata.id;
-
-    missionFungibleToken.save();
-    missionMetadata.save();
-    mission.save();
-    user.save();
-  }
-}
-export function handleTokenTransferred(event: TokenTransferred): void {
-  let context = dataSource.context();
-  let appAddress = Address.fromString(context.getString("App"));
-  let mission = loadOrCreateMission(
-    event.transaction.hash,
-    event.params.id,
+  let reward = loadOrCreateReward(
+    event.params.id.toString(),
+    event.params.activityType.toString(),
+    event.params.uri,
     event
-  );
+  )
 
-  let missionMetadata = loadOrCreateMissionMetadata(
-    event.transaction.hash,
-    event.params.id
-  );
+  reward.app = appAddress.toHex()
+  reward.rewardId = event.params.id.toString()
+  reward.rewardType = event.params.activityType.toString()
+  reward.metadataURI = event.params.uri
+  reward.user = user.id
 
-  let missionFungibleToken = loadOrCreateMissionFungibleToken(
-    event.transaction.hash,
-    event.params.id,
-    event.params.token
-  );
+  reward.token = token.id
+  reward.tokenAmount = event.params.amount
 
-  associateAppWithToken(appAddress, event.params.token, event);
+  reward.badgeCount = 0
 
-  let user = loadOrCreateUser(event.params.to, event);
-
-  missionFungibleToken.amount_rewarded = event.params.amount;
-  missionFungibleToken.mission = mission.id;
-  missionFungibleToken.token = event.params.token.toHex();
-
-  missionMetadata.name = event.params.id.toString();
-  missionMetadata.URI = event.params.uri;
-
-  mission.user = user.id;
-  mission.app = appAddress.toHex();
-  mission.metadata = missionMetadata.id;
-
-  missionFungibleToken.save();
-  missionMetadata.save();
-
-  mission.save();
-  user.save();
+  user.save()
+  token.save()
+  reward.save()
 }
 
+export function handleTokenTransferred(event: TokenTransferred): void {
+  DEPRECATED_handleTokenTransferred(event)
+
+  let context = dataSource.context();
+  let appAddress = Address.fromString(context.getString("App"));
+  let user = loadOrCreateUser(event.params.to, event);
+  let token = loadOrCreateFungibleToken(event.params.token, event)
+
+  let reward = loadOrCreateReward(
+    event.params.id.toString(),
+    event.params.activityType.toString(),
+    event.params.uri,
+    event
+  )
+
+  reward.app = appAddress.toHex()
+  reward.rewardId = event.params.id.toString()
+  reward.rewardType = event.params.activityType.toString()
+  reward.metadataURI = event.params.uri
+  reward.user = user.id
+
+  reward.token = token.id
+  reward.tokenAmount = event.params.amount
+
+  reward.badgeCount = 0
+
+  user.save()
+  token.save()
+  reward.save()
+}
 
 // handles ERC721 tokens being rewarded with the uri being emitted from the event
 export function handleERC721Minted(event: ERC721Minted): void {
-  handleERC721MintedEvent(new BadgeMintedParams(
-    event.params.token,
-    event.params.quantity,
-    event.params.to,
-    event.params.id,
-    event.params.activityType,
-    Bytes.fromByteArray(ByteArray.fromUTF8(event.params.uri))
-  ), event)
+  DEPRECATED_handleERC721Minted(event)
+
+  let context = dataSource.context();
+  let appAddress = Address.fromString(context.getString("App"));
+  let user = loadOrCreateUser(event.params.to, event);
+  let badge = loadOrCreateBadge(event.params.token, event)
+
+  let reward = loadOrCreateReward(
+    event.params.id.toString(),
+    event.params.activityType.toString(),
+    event.params.uri.toString(),
+    event
+  )
+
+  reward.app = appAddress.toHex()
+  reward.rewardId = event.params.id.toString()
+  reward.rewardType = event.params.activityType.toString()
+  reward.metadataURI = event.params.uri.toString()
+  reward.user = user.id
+
+  reward.badge = badge.id
+  let badges: Array<string> = []
+  let boundContract = BadgeContract.bind(event.params.token)
+  let totalSupply = boundContract.totalSupply()
+  let quantity = event.params.quantity
+  for (let i = 0; i < quantity.toI32(); i++) {
+    let id = totalSupply.minus(quantity).plus(BigInt.fromI32(i))
+    let badgeToken = loadOrCreateBadgeToken(
+      event.params.token,
+      id,
+      event
+    )
+
+    badgeToken.badge = badge.id
+    badgeToken.owner = user.id
+    badgeToken.metadataURI = badge.metadataURI ? null : event.params.uri.toString()
+    badgeToken.save()
+
+    badges.push(badgeToken.id)
+  }
+  reward.badges = badges
+  reward.badgeCount = badges.length
+
+  reward.tokenAmount = Zero
+
+  user.save()
+  badge.save()
+  reward.save()
 }
 
+// TODO: Remove as event no longer emitted from contracts, and only needed to maintain testnet history
 // handles ERC721 tokens being rewarded with the uri being emitted from the event
 // but with the event named BadgeMinted
 export function handleBadgeMintedLegacy(event: BadgeMinted1): void {
-  handleERC721MintedEvent(new BadgeMintedParams(
-    event.params.token,
-    event.params.quantity,
-    event.params.to,
-    event.params.id,
-    event.params.activityType,
-    Bytes.fromByteArray(ByteArray.fromUTF8(event.params.uri))
-  ), event)
+  DEPRECATED_handleBadgeMintedLegacy(event)
 }
 
 // handles ERC721 badge tokens being rewarded with the uri on the contract
 export function handleBadgeMinted(event: BadgeMinted): void {
-  handleERC721MintedEvent(new BadgeMintedParams(
-    event.params.token,
-    event.params.quantity,
-    event.params.to,
-    event.params.activityId,
-    event.params.activityType,
-    event.params.data
-  ), event)
-}
+  DEPRECATED_handleBadgeMinted(event)
 
-// takes a common param interface for erc721 minted events and indexes them
-// {
-//   token: Address;
-//   to: Address;
-//   quantity: BigInt;
-//   activityId: Bytes;
-//   activityType: Bytes;
-//   data: Bytes;
-// }
-function handleERC721MintedEvent(
-  params: BadgeMintedParams
-  , event: ethereum.Event): void {
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
+  let user = loadOrCreateUser(event.params.to, event);
+  let badge = loadOrCreateBadge(event.params.token, event)
 
-  let mission = loadOrCreateMission(
-    event.transaction.hash,
-    params.activityId,
+  let reward = loadOrCreateReward(
+    event.params.activityId.toString(),
+    event.params.activityType.toString(),
+    event.params.data.toString(),
     event
-  );
+  )
 
-  let boundContract = BadgeContract.bind(params.token);
+  reward.app = appAddress.toHex()
+  reward.rewardId = event.params.activityId.toString()
+  reward.rewardType = event.params.activityType.toString()
+  reward.metadataURI = event.params.data.toString()
+  reward.user = user.id
 
-  let missionMetadata = loadOrCreateMissionMetadata(
-    event.transaction.hash,
-    params.activityId
-  );
-  let user = loadOrCreateUser(params.to, event);
-  let badge = loadOrCreateBadge(params.token, event);
-  let badgeMetadataURI = badge.metadataURI
-  let totalSupply = boundContract.totalSupply();
-  let quantity = params.quantity;
-  let missionBadges = mission.badges;
-
-  //@DEV currently, if the same Badge gets rewarded in more that one mission in a single transactions
-  //we can't calculate the tokenId.
-
+  reward.badge = badge.id
+  let badges: Array<string> = []
+  let boundContract = BadgeContract.bind(event.params.token)
+  let totalSupply = boundContract.totalSupply()
+  let quantity = event.params.quantity
   for (let i = 0; i < quantity.toI32(); i++) {
-    let tokenId = totalSupply.minus(quantity).plus(BigInt.fromI32(i));
-    let missionBadge = loadOrCreateBadgeToken(
-      params.token,
-      tokenId,
+    let id = totalSupply.minus(quantity).plus(BigInt.fromI32(i))
+    let badgeToken = loadOrCreateBadgeToken(
+      event.params.token,
+      id,
       event
-    );
+    )
 
-    missionBadge.badge = params.token.toHex();
-    missionBadge.owner = user.id;
-    missionBadge.metadataURI = badgeMetadataURI ? null : params.data.toString();
+    badgeToken.badge = badge.id
+    badgeToken.owner = user.id
+    badgeToken.metadataURI = badge.metadataURI ? null : event.params.data.toString()
+    badgeToken.save()
 
-    missionBadge.save();
-
-    missionBadges.push(missionBadge.id);
+    badges.push(badgeToken.id)
   }
+  reward.badges = badges
+  reward.badgeCount = badges.length
 
-  missionMetadata.URI = params.data.toString();
-  missionMetadata.name = params.activityId.toString();
+  reward.tokenAmount = Zero
 
-  mission.user = user.id;
-  mission.app = appAddress.toHex();
-  mission.metadata = missionMetadata.id;
-  mission.badges = missionBadges;
-
-  missionMetadata.save();
-  mission.save();
-  user.save();
+  user.save()
+  badge.save()
+  reward.save()
 }
 
 export function handleBadgeTransferred(event: BadgeTransferred): void {
+  DEPRECATED_handleBadgeTransferred(event)
+
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
-
-  let mission = loadOrCreateMission(
-    event.transaction.hash,
-    event.params.id,
-    event
-  );
-
-  let missionMetadata = loadOrCreateMissionMetadata(
-    event.transaction.hash,
-    event.params.id
-  );
-
-  let missionBadge = loadBadgeToken(event.params.token, event.params.tokenId);
-
   let user = loadOrCreateUser(event.params.to, event);
-  missionMetadata.name = event.params.id.toString();
-  missionMetadata.URI = event.params.uri;
+  let badge = loadOrCreateBadge(event.params.token, event)
 
-  mission.user = user.id;
-  mission.app = appAddress.toHex();
-  mission.metadata = missionMetadata.id;
+  let reward = loadOrCreateReward(
+    event.params.id.toString(),
+    event.params.activityType.toString(),
+    event.params.uri.toString(),
+    event
+  )
 
-  let missionBadges = mission.badges;
+  reward.app = appAddress.toHex()
+  reward.rewardId = event.params.id.toString()
+  reward.rewardType = event.params.activityType.toString()
+  reward.metadataURI = event.params.uri.toString()
+  reward.user = user.id
 
-  if (missionBadges && missionBadge) {
-    missionBadges.push(missionBadge.id);
-    mission.badges = missionBadges;
-  }
+  reward.badge = badge.id
+  let badgeToken = loadOrCreateBadgeToken(
+    event.params.token,
+    event.params.tokenId,
+    event
+  )
+  badgeToken.badge = badge.id
+  badgeToken.owner = user.id
 
-  missionMetadata.save();
-  mission.save();
-  user.save();
-}
+  reward.badges = [badgeToken.id]
+  reward.badgeCount = 1
 
-function associateAppWithToken(appAddress: Address, tokenAddress: Address, event: ethereum.Event): void {
-  // Check token exists
-  let fungibleToken = FungibleToken.load(tokenAddress.toHex());
-  if (!fungibleToken) {
-    createExternalFungibleToken(tokenAddress, event);
-  }
-  // Ensure app has an association with fungibleToken
-  let appFungibleToken = loadOrCreateAppFungibleToken(appAddress, tokenAddress);
-  appFungibleToken.save();
-}
+  reward.tokenAmount = Zero
 
-export class BadgeMintedParams {
-  _token: Address
-  _quantity: BigInt
-  _to: Address
-  _activityId: Bytes
-  _activityType: Bytes
-  _data: Bytes
-
-  constructor(
-    token: Address,
-    quantity: BigInt,
-    to: Address,
-    activityId: Bytes,
-    activityType: Bytes,
-    data: Bytes
-  ) {
-    this._token = token
-    this._quantity = quantity
-    this._to = to
-    this._activityId = activityId
-    this._activityType = activityType
-    this._data = data
-  }
-
-  get token(): Address {
-    return this._token;
-  }
-
-  get quantity(): BigInt {
-    return this._quantity;
-  }
-
-  get to(): Address {
-    return this._to;
-  }
-
-  get activityId(): Bytes {
-    return this._activityId;
-  }
-
-  get activityType(): Bytes {
-    return this._activityType;
-  }
-
-  get data(): Bytes {
-    return this._data;
-  }
+  user.save()
+  reward.save()
+  badge.save()
+  badgeToken.save()
 }

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -117,11 +117,11 @@ export function handleERC721Minted(event: ERC721Minted): void {
   reward.metadataURI = event.params.uri.toString()
   reward.user = user.id
 
-  let badges = indexBadgeTokens(badge, event.params.quantity, user.id, event.params.uri.toString(), event)
+  let badgeTokens = indexBadgeTokens(badge, event.params.quantity, user.id, event.params.uri.toString(), event)
 
   reward.badge = badge.id
-  reward.badges = badges
-  reward.badgeCount = badges.length
+  reward.badgeTokens = badgeTokens
+  reward.badgeCount = badgeTokens.length
 
   reward.tokenAmount = Zero
 
@@ -153,11 +153,11 @@ export function handleBadgeMinted(event: BadgeMinted): void {
   reward.metadataURI = event.params.data.toString()
   reward.user = user.id
 
-  let badges = indexBadgeTokens(badge, event.params.quantity, user.id, event.params.data.toString(), event)
+  let badgeTokens = indexBadgeTokens(badge, event.params.quantity, user.id, event.params.data.toString(), event)
 
   reward.badge = badge.id
-  reward.badges = badges
-  reward.badgeCount = badges.length
+  reward.badgeTokens = badgeTokens
+  reward.badgeCount = badgeTokens.length
 
   reward.tokenAmount = Zero
 
@@ -205,7 +205,7 @@ export function handleBadgeTransferred(event: BadgeTransferred): void {
   badgeToken.save()
 
   reward.badge = badge.id
-  reward.badges = [badgeToken.id]
+  reward.badgeTokens = [badgeToken.id]
   reward.badgeCount = 1
 
   reward.tokenAmount = Zero
@@ -215,7 +215,7 @@ export function handleBadgeTransferred(event: BadgeTransferred): void {
 }
 
 function indexBadgeTokens(badge: Badge, quantity: BigInt, user: string, metadataURI: string, event: ethereum.Event): Array<string> {
-  let badges: Array<string> = []
+  let badgeTokens: Array<string> = []
   let badgeAddress = Address.fromString(badge.id)
   let boundContract = BadgeContract.bind(badgeAddress)
   let totalSupply = boundContract.totalSupply()
@@ -232,8 +232,8 @@ function indexBadgeTokens(badge: Badge, quantity: BigInt, user: string, metadata
     badgeToken.metadataURI = badge.metadataURI ? null : metadataURI
     badgeToken.save()
 
-    badges.push(badgeToken.id)
+    badgeTokens.push(badgeToken.id)
   }
 
-  return badges
+  return badgeTokens
 }

--- a/src/helpers/associate.ts
+++ b/src/helpers/associate.ts
@@ -1,0 +1,40 @@
+import { Address, ethereum } from "@graphprotocol/graph-ts";
+import { Badge, FungibleToken } from "../../generated/schema";
+import { createExternalBadge, createExternalFungibleToken } from "./create";
+import { loadOrCreateAppFungibleToken } from "./loadOrCreate";
+import { log } from "matchstick-as";
+
+export function associateAppWithToken(appAddress: Address, tokenAddress: Address, event: ethereum.Event): void {
+  // Check token exists
+  let fungibleToken = FungibleToken.load(tokenAddress.toHex())
+  if (!fungibleToken) {
+    createExternalFungibleToken(tokenAddress, event)
+  }
+  // Ensure app has an association with fungibleToken
+  let appFungibleToken = loadOrCreateAppFungibleToken(appAddress, tokenAddress)
+  appFungibleToken.save()
+}
+
+export function associateAppWithBadge(appAddress: Address, badgeAddress: Address, event: ethereum.Event): void {
+  // Check badge exists
+  let badge = Badge.load(badgeAddress.toHex())
+  if (!badge) {
+    badge = createExternalBadge(badgeAddress, event)
+  }
+
+  /*
+    TODO: make app-badge a many to many relationship, replace below if statement with the following:
+  // Ensure app has an association with badge
+  let appBadge = loadOrCreateAppBadge(appAddress, badgeAddress)
+  appBadge.save()
+  */
+
+  log.debug('badge.app: {}', [badge.app])
+  log.debug('app: {}', [appAddress.toHex()])
+
+  if (!badge.app) {
+    badge.app = appAddress.toHex()
+  }
+
+  badge.save()
+}

--- a/src/helpers/create.ts
+++ b/src/helpers/create.ts
@@ -1,9 +1,10 @@
-import { Address, ethereum, BigInt } from "@graphprotocol/graph-ts";
+import { Address, ethereum, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { ZERO_ADDRESS } from "./address";
-import { FungibleToken } from "../../generated/schema";
+import { Badge, FungibleToken } from "../../generated/schema";
 import { loadOrCreateUser } from "./loadOrCreate";
 import { ERC20Base as ERC20BaseContract } from "../../generated/templates/ERC20Base/ERC20Base";
 import { FUNGIBLE_TOKEN_TYPE_EXTERNAL } from "./enums";
+import { ERC721Base } from "../../generated/templates/ERC721Base/ERC721Base";
 
 /**
  * Use to index fungibleTokens not created by openformat contracts.
@@ -45,3 +46,42 @@ export function createExternalFungibleToken(
 
   return fungibleToken
 }
+
+/**
+ * Use to index badges (NFT contracts) not created by openformat contracts.
+ * @dev saves entities internally
+ */
+export function createExternalBadge(
+  badgeAddress: Address,
+  event: ethereum.Event
+): Badge {
+  let badge = new Badge(badgeAddress.toHex());
+
+  // need to call token to retrieve all the details
+  let boundContract = ERC721Base.bind(badgeAddress);
+  let zeroUser = loadOrCreateUser(Address.fromBytes(ZERO_ADDRESS), event);
+
+  // Try to fetch the token name, symbol and royalty info from contract
+  // if they revert fallback to "UNKNOWN"
+  let nameResult = boundContract.try_name();
+  badge.name = nameResult.reverted ? "UNKNOWN" : nameResult.value;
+  let symbolResult = boundContract.try_symbol();
+  badge.symbol = symbolResult.reverted ? "UNKNOWN" : symbolResult.value;
+  // TODO: read contract to get this info
+  badge.royaltyBps = BigInt.fromI32(0);
+  badge.royaltyRecipient = Bytes.fromHexString(zeroUser.id);
+
+  badge.totalAwarded = BigInt.fromI32(0);
+  badge.totalAvailable = BigInt.fromI32(0);
+
+  badge.createdAt = event.block.timestamp;
+  badge.createdAtBlock = event.block.number;
+  badge.updatedAt = event.block.timestamp;
+  badge.updatedAtBlock = event.block.number;
+
+  zeroUser.save();
+  badge.save();
+
+  return badge
+}
+

--- a/src/helpers/idTemplates.ts
+++ b/src/helpers/idTemplates.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { Address, BigInt, ByteArray, Bytes, crypto, ethereum } from "@graphprotocol/graph-ts";
 
 export function BadgeId(contractAddress: Address, tokenId: string): string {
   return contractAddress.toHex() + "-" + tokenId;
@@ -29,4 +29,13 @@ export function TokenBalanceId(
 
 export function AppFungibleTokenId(appAddress: Address, tokenAddress: Address): string {
   return appAddress.toHex() + "-" + tokenAddress.toHex();
+}
+
+export function RewardId(
+  label: String,
+  rewardType: String,
+  metadataURI: String,
+  event: ethereum.Event): string {
+  const rewardHash = crypto.keccak256(ByteArray.fromUTF8(`${label}|${rewardType}|${metadataURI}`))
+  return rewardHash.toHex() + "-" + event.transaction.hash.toHex() + "-" + event.logIndex.toString()
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,4 +3,5 @@ export * from "./idTemplates";
 export * from "./load";
 export * from "./loadOrCreate";
 export * from "./numbers";
-export * from "./create"
+export * from "./create";
+export * from "./associate";

--- a/src/helpers/loadOrCreate.ts
+++ b/src/helpers/loadOrCreate.ts
@@ -15,8 +15,9 @@ import {
   MissionMetadata,
   RequiredTokenBalance,
   User,
+  Reward
 } from "../../generated/schema";
-import { ActionId, AppFungibleTokenId, BadgeId, ChargeId, MissionId, RequiredTokenBalanceId, TokenBalanceId } from "./idTemplates";
+import { RewardId, ActionId, AppFungibleTokenId, BadgeId, ChargeId, MissionId, RequiredTokenBalanceId, TokenBalanceId } from "./idTemplates";
 import { Zero } from "./numbers";
 
 export function loadOrCreateApp(
@@ -94,6 +95,25 @@ export function loadOrCreateUser(
   _User.updatedAtBlock = event.block.number;
 
   return _User as User;
+}
+
+export function loadOrCreateReward(
+  label: String,
+  rewardType: String,
+  URI: String,
+  event: ethereum.Event
+): Reward {
+  const id = RewardId(label, rewardType, URI, event);
+  let reward = Reward.load(id);
+
+  if (!reward) {
+    reward = new Reward(id);
+    reward.transactionHash = event.transaction.hash.toHex()
+    reward.createdAt = event.block.timestamp;
+    reward.createdAtBlock = event.block.number;
+  }
+
+  return reward as Reward
 }
 
 export function loadOrCreateActionMetadata(

--- a/src/helpers/loadOrCreate.ts
+++ b/src/helpers/loadOrCreate.ts
@@ -116,6 +116,7 @@ export function loadOrCreateReward(
   return reward as Reward
 }
 
+// TODO: remove when action entity is removed from schema
 export function loadOrCreateActionMetadata(
   transactionHash: Bytes,
   logIndex: BigInt
@@ -130,6 +131,8 @@ export function loadOrCreateActionMetadata(
   return _ActionMetadata as ActionMetadata;
 }
 
+
+// TODO: remove when action entity is removed from schema
 export function loadOrCreateAction(
   transactionHash: Bytes,
   logIndex: BigInt,
@@ -147,6 +150,8 @@ export function loadOrCreateAction(
   return _Action as Action;
 }
 
+
+// TODO: remove when mission entity is removed from schema
 export function loadOrCreateMission(
   transactionHash: Bytes,
   actionId: Bytes,
@@ -166,6 +171,8 @@ export function loadOrCreateMission(
   return _Mission as Mission;
 }
 
+
+// TODO: remove when mission entity is removed from schema
 export function loadOrCreateMissionFungibleToken(
   transactionHash: Bytes,
   missionId: Bytes,
@@ -186,6 +193,7 @@ export function loadOrCreateMissionFungibleToken(
   return _MissionFungibleToken as MissionFungibleToken;
 }
 
+// TODO: remove when mission entity is removed from schema
 export function loadOrCreateMissionMetadata(
   transactionHash: Bytes,
   actionId: Bytes
@@ -237,25 +245,6 @@ export function loadOrCreateFungibleTokenMetadata(
 
   return _FungibleTokenMetadata as FungibleTokenMetadata;
 }
-
-// export function loadOrCreateToken(
-//   contractAddress: Address,
-//   event: ethereum.Event
-// ): Token {
-//   const id = contractAddress.toHex();
-//   let _Token = Token.load(id);
-
-//   if (!_Token) {
-//     _Token = new Token(id);
-//     _Token.createdAt = event.block.timestamp;
-//     _Token.createdAtBlock = event.block.number;
-//   }
-
-//   _Token.updatedAt = event.block.timestamp;
-//   _Token.updatedAtBlock = event.block.number;
-
-//   return _Token as Token;
-// }
 
 export function loadOrCreateFungibleTokenBalance(
   contractAddress: Address,

--- a/tests/facet/RewardsFacet.test.ts
+++ b/tests/facet/RewardsFacet.test.ts
@@ -1,7 +1,7 @@
 import { assert, createMockedFunction, clearStore, test, describe, afterEach, dataSourceMock, beforeEach } from "matchstick-as/assembly/index";
 import { createApp, createBadge, createERC20Token, getTestBadgeTokenEntity, badgeMintedLegacy, mintERC20TokenAction, mintERC20TokenMission, transferBadge, transferERC20TokenMission, badgeMinted, erc721Minted, updatedBaseURI } from "../utils";
-import { TEST_ACTIONMETADATA_ENTITY_TYPE, TEST_ACTION_ENTITY_TYPE, TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, TEST_APP_ID, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, TEST_MISSIONMETADATA_ENTITY_TYPE, TEST_MISSION_ENTITY_TYPE, TEST_TOKEN_DECIMALS, TEST_TOKEN_ID, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_MISSION_URI, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
-import { ActionId, AppFungibleTokenId, BadgeId, MissionId, ZERO_ADDRESS, loadBadgeToken } from "../../src/helpers";
+import { TEST_ACTIONMETADATA_ENTITY_TYPE, TEST_ACTION_ENTITY_TYPE, TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, TEST_APP_ID, TEST_BADGETOKEN_ENTITY_TYPE, TEST_BADGETOKEN_ID, TEST_BADGE_ID, TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, TEST_MISSIONMETADATA_ENTITY_TYPE, TEST_MISSION_ENTITY_TYPE, TEST_REWARD_ENTITY_TYPE, TEST_TOKEN_DECIMALS, TEST_TOKEN_ID, TEST_TOKEN_MINTED_ACTION_ID, TEST_TOKEN_MINTED_MISSION, TEST_TOKEN_MINTED_MISSION_ID, TEST_TOKEN_MINTED_MISSION_URI, TEST_TOKEN_MINTED_URI, TEST_TOKEN_NAME, TEST_TOKEN_SYMBOL, TEST_TOKEN_TOTAL_SUPPLY, TEST_USER2_ID, TEST_USER3_ID, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "../fixtures";
+import { ActionId, AppFungibleTokenId, BadgeId, MissionId, RewardId, ZERO_ADDRESS, Zero, loadBadgeToken } from "../../src/helpers";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Mission } from "../../generated/schema";
 
@@ -32,6 +32,24 @@ describe("RewardsFacet tests", () => {
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "id", actionId);
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "name", TEST_TOKEN_MINTED_ACTION_ID);
         assert.fieldEquals(TEST_ACTIONMETADATA_ENTITY_TYPE, actionId, "URI", TEST_TOKEN_MINTED_MISSION_URI);
+
+        const rewardId = RewardId(
+            TEST_TOKEN_MINTED_ACTION_ID,
+            "ACTION",
+            TEST_TOKEN_MINTED_MISSION_URI,
+            event
+        );
+
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_ACTION_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", "ACTION");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "token", TEST_TOKEN_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", event.params.amount.toString());
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", "0");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
     })
 
     test("Token minted MISSION", () => {
@@ -62,6 +80,24 @@ describe("RewardsFacet tests", () => {
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "mission", missionId);
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "token", event.params.token.toHex());
+
+        const rewardId = RewardId(
+            TEST_TOKEN_MINTED_MISSION_ID,
+            TEST_TOKEN_MINTED_MISSION,
+            TEST_TOKEN_MINTED_MISSION_URI,
+            event
+        );
+
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_MISSION_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", TEST_TOKEN_MINTED_MISSION);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "token", TEST_TOKEN_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", event.params.amount.toString());
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", "0");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
     })
 
     test("Token transferred MISSION", () => {
@@ -93,6 +129,24 @@ describe("RewardsFacet tests", () => {
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "amount_rewarded", event.params.amount.toString());
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "mission", missionId);
         assert.fieldEquals(TEST_MISSIONFUNGIBLETOKEN_ENTITY_TYPE, missionFungibleTokenId, "token", event.params.token.toHex());
+
+        const rewardId = RewardId(
+            TEST_TOKEN_MINTED_MISSION_ID,
+            TEST_TOKEN_MINTED_MISSION,
+            TEST_TOKEN_MINTED_MISSION_URI,
+            event
+        );
+
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_MISSION_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", TEST_TOKEN_MINTED_MISSION);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "token", TEST_TOKEN_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", event.params.amount.toString());
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", "0");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
     })
 
     describe("When Token is external", () => {
@@ -142,6 +196,24 @@ describe("RewardsFacet tests", () => {
             assert.fieldEquals(TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, appFungibleTokenId, "id", appFungibleTokenId);
             assert.fieldEquals(TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, appFungibleTokenId, "app", TEST_APP_ID);
             assert.fieldEquals(TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, appFungibleTokenId, "token", TEST_TOKEN_ID);
+
+            const rewardId = RewardId(
+                TEST_TOKEN_MINTED_MISSION_ID,
+                TEST_TOKEN_MINTED_MISSION,
+                TEST_TOKEN_MINTED_MISSION_URI,
+                event
+            );
+
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_MISSION_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", TEST_TOKEN_MINTED_MISSION);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "token", TEST_TOKEN_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", event.params.amount.toString());
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", "0");
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
         })
 
         test("Token minted MISSION", () => {
@@ -174,6 +246,24 @@ describe("RewardsFacet tests", () => {
             assert.fieldEquals(TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, appFungibleTokenId, "id", appFungibleTokenId);
             assert.fieldEquals(TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, appFungibleTokenId, "app", TEST_APP_ID);
             assert.fieldEquals(TEST_APPFUNGIBLETOKEN_ENTITY_TYPE, appFungibleTokenId, "token", TEST_TOKEN_ID);
+
+            const rewardId = RewardId(
+                TEST_TOKEN_MINTED_MISSION_ID,
+                TEST_TOKEN_MINTED_MISSION,
+                TEST_TOKEN_MINTED_MISSION_URI,
+                event
+            );
+
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_MISSION_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", TEST_TOKEN_MINTED_MISSION);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "token", TEST_TOKEN_ID);
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", event.params.amount.toString());
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", "0");
+            assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
         })
     })
 
@@ -260,6 +350,24 @@ describe("RewardsFacet tests", () => {
                 assert.assertNotNull(badgeToken)
             }
         }
+
+        const rewardId = RewardId(
+            TEST_TOKEN_MINTED_MISSION_ID,
+            TEST_TOKEN_MINTED_MISSION,
+            TEST_TOKEN_MINTED_MISSION_URI,
+            event
+        );
+
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_MISSION_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", TEST_TOKEN_MINTED_MISSION);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", "0");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badge", TEST_TOKEN_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", event.params.quantity.toString());
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
     })
 
     test("ERC721 token minted", () => {
@@ -299,6 +407,24 @@ describe("RewardsFacet tests", () => {
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, id, "metadataURI", event.params.uri);
             assert.fieldEquals(TEST_BADGETOKEN_ENTITY_TYPE, id, "owner", event.params.to.toHex());
         }
+
+        const rewardId = RewardId(
+            TEST_TOKEN_MINTED_MISSION_ID,
+            TEST_TOKEN_MINTED_MISSION,
+            TEST_TOKEN_MINTED_MISSION_URI,
+            event
+        );
+
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_MISSION_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", TEST_TOKEN_MINTED_MISSION);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", "0");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badge", TEST_TOKEN_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", event.params.quantity.toString());
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
     })
 
     test("Badge token transfer", () => {
@@ -333,6 +459,24 @@ describe("RewardsFacet tests", () => {
         assert.assertTrue(mission!.badges != null, "Mission has badges");
         assert.assertTrue(mission!.badges.length == 1, "Mission badges has length = 1");
         assert.assertTrue(mission!.badges.at(0) == badgeToken.id, "Badge is ok");
+
+        const rewardId = RewardId(
+            TEST_TOKEN_MINTED_MISSION_ID,
+            TEST_TOKEN_MINTED_MISSION,
+            TEST_TOKEN_MINTED_MISSION_URI,
+            event
+        );
+
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "id", rewardId);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "app", TEST_APP_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardId", TEST_TOKEN_MINTED_MISSION_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "rewardType", TEST_TOKEN_MINTED_MISSION);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "metadataURI", TEST_TOKEN_MINTED_MISSION_URI);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "user", TEST_USER3_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "tokenAmount", "0");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badge", TEST_TOKEN_ID);
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "badgeCount", "1");
+        assert.fieldEquals(TEST_REWARD_ENTITY_TYPE, rewardId, "transactionHash", event.transaction.hash.toHex());
     })
 
 });

--- a/tests/facet/RewardsFacet.test.ts
+++ b/tests/facet/RewardsFacet.test.ts
@@ -264,6 +264,7 @@ describe("RewardsFacet tests", () => {
 
     test("ERC721 token minted", () => {
         createApp();
+        createBadge();
 
         const totalSupply = BigInt.fromString(TEST_TOKEN_TOTAL_SUPPLY);
         createMockedFunction(Address.fromString(TEST_TOKEN_ID), "totalSupply", "totalSupply():(uint256)")
@@ -300,8 +301,9 @@ describe("RewardsFacet tests", () => {
         }
     })
 
-    test("Badge transfer", () => {
+    test("Badge token transfer", () => {
         createApp();
+        createBadge();
 
         const badgeToken = getTestBadgeTokenEntity(
             Address.fromString(TEST_TOKEN_ID),

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -17,6 +17,7 @@ export const TEST_NFT_ENTITY_TYPE = "NFT";
 export const TEST_TOKEN_ENTITY_TYPE = "Token";
 export const TEST_USER_ENTITY_TYPE = "User";
 export const TEST_CHARGE_ENTITY_TYPE = "Charge";
+export const TEST_REWARD_ENTITY_TYPE = "Reward";
 export const TEST_REQUIREDTOKENBALANCE_ENTITY_TYPE = "RequiredTokenBalance"
 export const TEST_APPFUNGIBLETOKEN_ENTITY_TYPE = "AppFungibleToken";
 


### PR DESCRIPTION
## Overview
- Adds new `Reward` entity that aims to replace both `Mission` and `Action` 
- Depreciates mission and action entities (still supported, but will remove once we are sure no one is using them)
- Refactors reward facet handlers for easier removal of deprecated functionality in the future
### Cleanup
- Removes `collectedBadges` entity from schema as it is unused
- Removes TODO's in schema

## Reasoning

### The name `Reward`

The name `Reward` has been chosen as it fits the current use case without over abstracting. `Event` was considered but it is similar to events in solidity and felt it was quite confusing from a dev perspective. Events also felt too abstract for right now and I didn't want take that name and have to settle for something worse later. I'm more than open to other suggestions on this.

Resulting schema
```graphql
type Reward @entity (immutable: true) {
  id: ID!
  app: App!
  rewardId: String!
  rewardType: String!
  metadataURI: String!
  user: User!
  token: FungibleToken
  tokenAmount: BigInt!
  badge: Badge
  badges: [BadgeToken!]
  badgeCount: Int!
  transactionHash: String!
  createdAt: BigInt!
  createdAtBlock: BigInt!
}
```

The aim is to improve developer experience by having a less opinionated data structure. By changing the approach in two distinct ways, have the type as a field and don't bundle tokens, we are able to achieve a flat data structure that should be much easier to query against. Moving forward it will be much easier to aggregate also.

### The field `rewardType`
`rewardType` will be `MISSION` for missions and `ACTION` for actions. This should mean we can easily move to using the `Reward` entity in the api by just changing the queries and not have to change the reward endpoints immediately. We can open it up to any `rewardType` so that devs can decide how they organise their rewards. For example `discord:mission`, `telegram:mission` will let us give more insight into where the rewards were triggered while keeping `rewardId` to the "for what"

### No bundling happens at a subgraph level

An important difference to note is `Missions` currently bundles tokens and badges rewarded in the same transaction so that badges and tokens could be linked to one mission. `Rewards` are less opinionated and follow the contract logic on the reward facet exactly.

#### Pros:
- Simpler schema, and handling logic
- `Multicall` can now be used to issue lots of different rewards at once
- Aggregations is easier to implement

#### Cons:
- Bundling would need to happen on the client, via their own logic

To add bundling back in I propose we add it at the contract level and then create a parent entity that groups `Reward` entities. Or have an explicit bundling logic that does not hinder the functionality of multicall

## Staging

I have deployed `v0.1.1-alpha` to staging to help with review
[Playground ->](https://subgraph.satsuma-prod.com/openformat--330570/open-format-arbitrum-sepolia-staging/version/v0.1.1-alpha/playground)

Example query
```graphql
{
  # Mission replacement query
  missions: rewards(where: {rewardType: "MISSION"}) {
    rewardId
    rewardType
    metadataURI
    token {
      id
    }
    tokenAmount
    badge{
      id
    }
    badges {
      tokenId
    }
    badgeCount
  }

  # Action replacement query
  actions: rewards(where: {rewardType: "ACTION"}) {
    rewardId
    rewardType
    metadataURI
    token {
      id
    }
    tokenAmount
    badge{
      id
    }
    badges {
      tokenId
    }
    badgeCount
  }
}
``` 