### PR TITLE
Feature: Fly graph-node deployment and Turbo configs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Execute Tests
     steps:
       - uses: actions/checkout@v3

--- a/env/openformat-graph-node-staging/Dockerfile
+++ b/env/openformat-graph-node-staging/Dockerfile
@@ -1,0 +1,2 @@
+FROM graphprotocol/graph-node:v0.36.0
+RUN apt-get install -y socat

--- a/env/openformat-graph-node-staging/fly.toml
+++ b/env/openformat-graph-node-staging/fly.toml
@@ -1,0 +1,57 @@
+# fly.toml app configuration file generated for openformat-turbo-graph-node-staging on 2025-01-08T19:31:39-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'openformat-turbo-graph-node-staging'
+primary_region = 'lhr'
+
+[env]
+  ipfs = "https://ipfs.satsuma.xyz"
+  ethereum = "turbo:https://rpc-0x4e45415f.aurora-cloud.dev"
+  GRAPH_LOG = "debug"
+
+[experimental]
+  allowed_public_ports = []
+
+[[services]]
+  http_checks = []
+  internal_port = 8000
+  protocol = "tcp"
+  script_checks = []
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+[[services]]
+  http_checks = []
+  internal_port = 8030
+  protocol = "tcp"
+  script_checks = []
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 8030
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 2

--- a/networks/turbo.json
+++ b/networks/turbo.json
@@ -1,0 +1,7 @@
+{
+  "network": "turbo",
+  "AppFactory": {
+    "address": "0x7e405FbA4c29B8B05B5ecF97bA664729C34803B8",
+    "startBlock": 136726407
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "prepare:arbitrum-sepolia": "mustache networks/arbitrum-sepolia.json subgraph.template.yaml subgraph.arbitrum-sepolia.yaml",
     "prepare:arbitrum-sepolia-staging": "mustache networks/arbitrum-sepolia-staging.json subgraph.template.yaml subgraph.arbitrum-sepolia-staging.yaml",
     "prepare:amoy": "mustache networks/amoy.json subgraph.template.yaml subgraph.amoy.yaml",
+    "prepare:turbo": "mustache networks/turbo.json subgraph.template.yaml subgraph.turbo.yaml",
 
     "create:local": "graph create open-format-local --node http://0.0.0.0:8020",
     "create:mumbai": "dotenv cross-var -- graph create open-format/mumbai --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
     "create:aurora": "dotenv cross-var -- graph create open-format/aurora --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
     "create:aurora-testnet": "dotenv cross-var -- graph create open-format/aurora-testnet --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
+    "create:turbo": "graph create open-format-local --node http://127.0.0.1:8020",
 
     "gen:mumbai": "graph codegen subgraph.mumbai.yaml",
     "gen:polygon": "graph codegen subgraph.polygon.yaml",
@@ -31,6 +33,7 @@
     "gen:arbitrum-sepolia-staging": "graph codegen subgraph.arbitrum-sepolia-staging.yaml",
     "gen:local": "graph codegen subgraph.local.yaml",
     "gen:amoy": "graph codegen subgraph.amoy.yaml",
+    "gen:turbo": "graph codegen subgraph.turbo.yaml",
     
     "deploy:local": "graph deploy open-format-local --ipfs http://0.0.0.0:5001 --node http://0.0.0.0:8020 subgraph.local.yaml",
     "deploy:mumbai": "dotenv cross-var -- graph deploy --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% --ipfs http://%IPFS_URL% open-format/mumbai subgraph.mumbai.yaml",
@@ -38,6 +41,7 @@
     "deploy:base": "graph deploy --studio open-format-base subgraph.base.yaml",
     "deploy:aurora": "graph deploy --studio open-format-aurora subgraph.aurora.yaml",
     "deploy:aurora-testnet": "graph deploy --studio open-format-aurora-testnet subgraph.aurora-testnet.yaml",
+    "deploy:turbo": "graph deploy open-format-local --ipfs https://ipfs.satsuma.xyz --node http://127.0.0.1:8020 subgraph.turbo.yaml",
 
     "remove:aurora-testnet": "dotenv cross-var -- graph remove --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% open-format/aurora-testnet",
 


### PR DESCRIPTION
## Summary

This PR adds Fly.io deployment for graph-node and Turbo chain configs.

## Description

Turbo chain network file and graph commands have been added.

Config files for new deployment in Fly.io have been added.

**Note:** workflow file needed to be updated because `ubuntu-latest` for Github Actions is now `Ubuntu 24.04` and `graph-cli` does not have support for that version yet. [1](https://github.com/actions/runner-images/issues/10636) [2](https://github.com/graphprotocol/graph-tooling/issues/1546) [3](https://github.com/graphprotocol/graph-tooling/blob/93d87a8c6912b87ed8dbdce0e1b4d2765bc1df39/packages/cli/src/commands/test.ts#L175)

## Type of Change

Please check the boxes that apply to your pull request:

- [X] New feature (non-breaking change which adds functionality)
