### PR TITLE
Feature/of 504 user metrics in subgraph 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Execute Tests
     steps:
       - uses: actions/checkout@v3

--- a/src/AppFactory.ts
+++ b/src/AppFactory.ts
@@ -14,6 +14,7 @@ import {
 export function handleCreated(event: Created): void {
   let context = new DataSourceContext();
   context.setString("App", event.params.id.toHex());
+  context.setBoolean("AggregationFeatureFlag", true);
 
   ERC721FactoryFacet.createWithContext(event.params.id, context);
   ERC20FactoryFacet.createWithContext(event.params.id, context);

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -56,9 +56,11 @@ export function handleTokenMinted(event: TokenMinted): void {
   token.save()
   reward.save()
 
-  saveRewardTokenData(reward, event);
-  saveUserRewardData(appAddress, event.params.to, event);
-  saveAppRewardId(appAddress, reward.rewardId, event);
+  if (context.getBoolean("AggregationFeatureFlag")) {
+    saveRewardTokenData(reward, event);
+    saveUserRewardData(appAddress, event.params.to, event);
+    saveAppRewardId(appAddress, reward.rewardId, event);
+  }
 }
 
 export function handleTokenTransferred(event: TokenTransferred): void {
@@ -90,9 +92,11 @@ export function handleTokenTransferred(event: TokenTransferred): void {
   token.save()
   reward.save()
 
-  saveRewardTokenData(reward, event);
-  saveUserRewardData(appAddress, event.params.to, event);
-  saveAppRewardId(appAddress, reward.rewardId, event);
+  if (context.getBoolean("AggregationFeatureFlag")) {
+    saveRewardTokenData(reward, event);
+    saveUserRewardData(appAddress, event.params.to, event);
+    saveAppRewardId(appAddress, reward.rewardId, event);
+  }
 }
 
 // handles ERC721 tokens being rewarded with the uri being emitted from the event
@@ -127,9 +131,11 @@ export function handleERC721Minted(event: ERC721Minted): void {
   user.save()
   reward.save()
 
-  saveRewardBadgeData(reward, event);
-  saveUserRewardData(appAddress, event.params.to, event);
-  saveAppRewardId(appAddress, reward.rewardId, event);
+  if (context.getBoolean("AggregationFeatureFlag")) {
+    saveRewardBadgeData(reward, event);
+    saveUserRewardData(appAddress, event.params.to, event);
+    saveAppRewardId(appAddress, reward.rewardId, event);
+  }
 }
 
 // handles ERC721 badge tokens being rewarded with the uri on the contract
@@ -164,9 +170,11 @@ export function handleBadgeMinted(event: BadgeMinted): void {
   user.save()
   reward.save()
 
-  saveRewardBadgeData(reward, event);
-  saveUserRewardData(appAddress, event.params.to, event);
-  saveAppRewardId(appAddress, reward.rewardId, event);
+  if (context.getBoolean("AggregationFeatureFlag")) {
+    saveRewardBadgeData(reward, event);
+    saveUserRewardData(appAddress, event.params.to, event);
+    saveAppRewardId(appAddress, reward.rewardId, event);
+  }
 }
 
 // TODO: Remove as event no longer emitted from contracts, and only needed to maintain arbitrum-sepolia history
@@ -215,9 +223,11 @@ export function handleBadgeTransferred(event: BadgeTransferred): void {
   user.save()
   reward.save()
 
-  saveRewardBadgeData(reward, event);
-  saveUserRewardData(appAddress, event.params.to, event);
-  saveAppRewardId(appAddress, reward.rewardId, event);
+  if (context.getBoolean("AggregationFeatureFlag")) {
+    saveRewardBadgeData(reward, event);
+    saveUserRewardData(appAddress, event.params.to, event);
+    saveAppRewardId(appAddress, reward.rewardId, event);
+  }
 }
 
 function indexBadgeTokens(badge: Badge, quantity: BigInt, user: string, metadataURI: string, event: ethereum.Event): Array<string> {

--- a/src/helpers/create.ts
+++ b/src/helpers/create.ts
@@ -98,7 +98,7 @@ export function saveRewardTokenData(reward: Reward, event: ethereum.Event): void
   rewardData.userId           = reward.user;
   rewardData.tokenId          = reward.token;
   rewardData.tokenAmount      = reward.tokenAmount;
-  rewardData.badgeCount       = 0;
+  rewardData.badgeTokenCount  = 0;
   rewardData.save()
 
   const rewardTokenData           = new RewardTokenData("auto");
@@ -124,7 +124,7 @@ export function saveRewardBadgeData(reward: Reward, event: ethereum.Event): void
   rewardData.metadataURI      = reward.metadataURI;
   rewardData.userId           = reward.user;
   rewardData.badgeId          = reward.badge;
-  rewardData.badgeCount       = reward.badgeCount;
+  rewardData.badgeTokenCount  = reward.badgeCount;
   rewardData.tokenAmount      = Zero;
   rewardData.save()
 
@@ -137,7 +137,7 @@ export function saveRewardBadgeData(reward: Reward, event: ethereum.Event): void
   rewardBadgeData.metadataURI     = reward.metadataURI;
   rewardBadgeData.userId          = reward.user;
   rewardBadgeData.badgeId         = reward.badge;
-  rewardBadgeData.badgeCount      = reward.badgeCount;
+  rewardBadgeData.badgeTokenCount = reward.badgeCount;
   rewardBadgeData.save();
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -90,6 +90,11 @@ export function createApp(): AppCreated {
   // Set the app in context so it is accessible
   let context = new DataSourceContext()
   context.set('App', Value.fromString(TEST_APP_ID))
+
+  // Matchstick doesn't support aggregation features.
+  // Setting this flag to false prevents aggregation functions from running during tests.
+  context.set("AggregationFeatureFlag", Value.fromBoolean(false))
+
   dataSourceMock.setReturnValues(TEST_APP_ID, 'App', context)
 
   return appEvent;


### PR DESCRIPTION
Adds a feature flag for aggregations so we can prevent functionality that uses aggregation from running in tests. The reason being matchstick doesn't support aggregation features.

Noted, It is a bit of a hack using the app context for this reason. However the subgraph.yaml has no way to configure custom constants or ENV variables.

All existing tests now work