### PR TITLE
Feature/of 734 check erc721 implementation contains badge in subgraph

### DIFF
--- a/src/facet/ERC20Factory.ts
+++ b/src/facet/ERC20Factory.ts
@@ -22,13 +22,13 @@ export function handleCreated(event: Created): void {
   let tokenType = FUNGIBLE_TOKEN_TYPE_BASE;
 
   let implementationId = event.params.implementationId.toString();
-  if (implementationId == "Base") {
-    ERC20Context.setString("ERC20BaseContract", event.params.id.toHex());
-    ERC20Base.createWithContext(event.params.id, ERC20Context);
-  } else {
+  if (implementationId.startsWith("Point")) {
     ERC20Context.setString("ERC20PointContract", event.params.id.toHex());
     ERC20Point.createWithContext(event.params.id, ERC20Context);
     tokenType = FUNGIBLE_TOKEN_TYPE_POINT
+  } else {
+    ERC20Context.setString("ERC20BaseContract", event.params.id.toHex());
+    ERC20Base.createWithContext(event.params.id, ERC20Context);
   }
 
 

--- a/src/facet/ERC721Factory.ts
+++ b/src/facet/ERC721Factory.ts
@@ -20,10 +20,10 @@ export function handleCreated(event: Created): void {
   let ERC721Context = new DataSourceContext();
 
   let implementationId = event.params.implementationId.toString();
-  if (implementationId == "LazyMint") {
+  if (implementationId.startsWith("LazyMint")) {
     ERC721Context.setString("ERC721ContractLazyMint", event.params.id.toHex());
     ERC721LazyMint.createWithContext(event.params.id, ERC721Context);
-  } else if (implementationId == "Badge") {
+  } else if (implementationId.startsWith("Badge")) {
     ERC721Context.setString("ERC721ContractBadge", event.params.id.toHex());
     ERC721Badge.createWithContext(event.params.id, ERC721Context);
   } else {


### PR DESCRIPTION
To easily add similar implementations of contracts without needing to update the subgraph we can check the implementation id starts with supported implementations.

This would that ERC721 contract implementation "BadgeNonTransferable" would be indexed as a badge. And in the future we can add other sub implementations to the contracts e.g "Badge<Implementation-sub-type>" without needing to update the subgraph.