### PR TITLE
Feature/of 791 improve process of adding chains to hosted graph node

### DIFF
--- a/env/openformat-deployer-staging/Dockerfile
+++ b/env/openformat-deployer-staging/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx
+
+RUN apt-get update && apt-get install -y apache2-utils
+
+COPY entrypoint.sh /entrypoint.sh
+COPY nginx.conf /etc/nginx/nginx.conf
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/env/openformat-deployer-staging/entrypoint.sh
+++ b/env/openformat-deployer-staging/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Check if the PASSWORD environment variable is set
+if [ -z "$PASSWORD" ]; then
+    echo "ERROR: PASSWORD environment variable is not set!"
+    exit 1
+fi
+
+# Create or update the .htpasswd file with the provided password
+htpasswd -b -c /etc/nginx/.htpasswd admin $PASSWORD
+
+# Start Nginx
+exec "$@"

--- a/env/openformat-deployer-staging/fly.toml
+++ b/env/openformat-deployer-staging/fly.toml
@@ -1,0 +1,20 @@
+# fly.toml app configuration file generated for openformat-deployer-staging on 2025-03-25T02:12:22-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'openformat-deployer-staging'
+primary_region = 'lhr'
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/env/openformat-deployer-staging/fly.toml
+++ b/env/openformat-deployer-staging/fly.toml
@@ -9,9 +9,9 @@ primary_region = 'lhr'
 [http_service]
   internal_port = 80
   force_https = true
-  auto_stop_machines = 'stop'
-  auto_start_machines = true
-  min_machines_running = 0
+  auto_stop_machines = false
+  auto_start_machines = false
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]

--- a/env/openformat-deployer-staging/nginx.conf
+++ b/env/openformat-deployer-staging/nginx.conf
@@ -1,0 +1,21 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            auth_basic "Restricted Access";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+
+            proxy_pass http://openformat-graph-node-staging.internal:8020;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}
+

--- a/env/openformat-graph-node-staging/Dockerfile
+++ b/env/openformat-graph-node-staging/Dockerfile
@@ -1,0 +1,4 @@
+FROM graphprotocol/graph-node:v0.36.0
+RUN apt-get install -y socat
+COPY ./config.toml /config.toml
+COPY ./start /usr/local/bin/

--- a/env/openformat-graph-node-staging/config.toml
+++ b/env/openformat-graph-node-staging/config.toml
@@ -1,0 +1,22 @@
+[store]
+[store.primary]
+connection = "postgresql://${postgres_user}:${postgres_pass}@${postgres_host}/${postgres_db}"
+pool_size = 50
+
+[chains]
+ingestor = "block_ingestor_node"
+[chains.openformat]
+shard = "primary"
+provider = [
+  { label = "openformat", url = "https://rpc-0x4e454168.aurora-cloud.dev/", transport="rpc", features = [ "archive", "traces" ] },
+]
+[chains.turbo]
+shard = "primary"
+provider = [
+  { label = "turbo", url = "https://rpc-0x4e45415f.aurora-cloud.dev", transport="rpc", features = [ "archive", "traces" ] },
+]
+
+[deployment]
+[[deployment.rule]]
+shard = "primary"
+indexers = ["default"]

--- a/env/openformat-graph-node-staging/fly.toml
+++ b/env/openformat-graph-node-staging/fly.toml
@@ -1,0 +1,57 @@
+# fly.toml app configuration file generated for openformat-turbo-graph-node-staging on 2025-01-08T19:31:39-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'openformat-graph-node-staging'
+primary_region = 'lhr'
+
+[env]
+  ipfs = "https://ipfs.satsuma.xyz"
+  GRAPH_NODE_CONFIG = "/config.toml"
+  GRAPH_LOG = "debug"
+
+[experimental]
+  allowed_public_ports = []
+
+[[services]]
+  http_checks = []
+  internal_port = 8000
+  protocol = "tcp"
+  script_checks = []
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+[[services]]
+  http_checks = []
+  internal_port = 8030
+  protocol = "tcp"
+  script_checks = []
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 8030
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 2

--- a/env/openformat-graph-node-staging/start
+++ b/env/openformat-graph-node-staging/start
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Modifiend version of https://github.com/graphprotocol/graph-node/blob/master/docker/start
+# Differences from original:
+# - Added socat execution to function `run_graph_node()`
+
 save_coredumps() {
     graph_dir=/var/lib/graph
     datestamp=$(date +"%Y-%m-%dT%H:%M:%S")

--- a/env/openformat-graph-node-staging/start
+++ b/env/openformat-graph-node-staging/start
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+save_coredumps() {
+    graph_dir=/var/lib/graph
+    datestamp=$(date +"%Y-%m-%dT%H:%M:%S")
+    ls /core.* >& /dev/null && have_cores=yes || have_cores=no
+    if [ -d "$graph_dir" -a "$have_cores" = yes ]
+    then
+        core_dir=$graph_dir/cores
+        mkdir -p $core_dir
+        exec >> "$core_dir"/messages 2>&1
+        echo "${HOSTNAME##*-} Saving core dump on ${HOSTNAME} at ${datestamp}"
+
+        dst="$core_dir/$datestamp-${HOSTNAME}"
+        mkdir "$dst"
+        cp /usr/local/bin/graph-node "$dst"
+        cp /proc/loadavg "$dst"
+        [ -f /Dockerfile ] && cp /Dockerfile "$dst"
+        tar czf "$dst/etc.tgz" /etc/
+        dmesg -e > "$dst/dmesg"
+        # Capture environment variables, but filter out passwords
+        env | sort | sed -r -e 's/^(postgres_pass|ELASTICSEARCH_PASSWORD)=.*$/\1=REDACTED/' > "$dst/env"
+
+        for f in /core.*
+        do
+            echo "${HOSTNAME##*-} Found core dump $f"
+            mv "$f" "$dst"
+        done
+        echo "${HOSTNAME##*-} Saving done"
+    fi
+}
+
+wait_for_ipfs() {
+    # Take the IPFS URL in $1 apart and extract host and port. If no explicit
+    # port is given, use 443 for https, and 80 otherwise
+    if [[ "$1" =~ ^((https?)://)?((.*)@)?([^:/]+)(:([0-9]+))? ]]
+    then
+        proto=${BASH_REMATCH[2]:-http}
+        host=${BASH_REMATCH[5]}
+        port=${BASH_REMATCH[7]}
+        if [ -z "$port" ]
+        then
+            [ "$proto" = "https" ] && port=443 || port=80
+        fi
+        echo "Waiting for IPFS ($host:$port)"
+        wait_for "$host:$port" -t 120
+    else
+        echo "invalid IPFS URL: $1"
+        exit 1
+    fi
+}
+
+run_graph_node() {
+    echo "Forwarding IPv6 traffic to IPv4 on port 8020"
+    nohup socat TCP6-LISTEN:8020,bind=[::],reuseaddr,ipv6only=1,fork TCP4:127.0.0.1:8020 &
+    if [ -n "$GRAPH_NODE_CONFIG" ]
+    then
+        # Start with a configuration file; we don't do a check whether
+        # postgres is up in this case, though we probably should
+        wait_for_ipfs "$ipfs"
+        sleep 5
+        exec graph-node \
+            --node-id "$node_id" \
+            --config "$GRAPH_NODE_CONFIG" \
+            --ipfs "$ipfs" \
+            ${fork_base:+ --fork-base "$fork_base"}
+    else
+        unset GRAPH_NODE_CONFIG
+        postgres_port=${postgres_port:-5432}
+        postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host:$postgres_port/$postgres_db?$postgres_args"
+
+        wait_for_ipfs "$ipfs"
+        echo "Waiting for Postgres ($postgres_host:$postgres_port)"
+        wait_for "$postgres_host:$postgres_port" -t 120
+        sleep 5
+
+        exec graph-node \
+            --node-id "$node_id" \
+            --postgres-url "$postgres_url" \
+            --ethereum-rpc $ethereum \
+            --ipfs "$ipfs" \
+            ${fork_base:+ --fork-base "$fork_base"}
+    fi
+}
+
+start_query_node() {
+    # Query nodes are never the block ingestor
+    export DISABLE_BLOCK_INGESTOR=true
+    run_graph_node
+}
+
+start_index_node() {
+    run_graph_node
+}
+
+start_combined_node() {
+    # No valid reason to disable the block ingestor in this case.
+    unset DISABLE_BLOCK_INGESTOR
+    run_graph_node
+}
+
+# Only the index node with the name set in BLOCK_INGESTOR should ingest
+# blocks. For historical reasons, that name is set to the unmangled version
+# of `node_id` and we need to check whether we are the block ingestor
+# before possibly mangling the node_id.
+if [[ ${node_id} != "${BLOCK_INGESTOR}" ]]; then
+    export DISABLE_BLOCK_INGESTOR=true
+fi
+
+# Allow operators to opt out of legacy character
+# restrictions on the node ID by setting enablement
+# variable to a non-zero length string:
+if [ -z "$GRAPH_NODE_ID_USE_LITERAL_VALUE" ]
+then
+	node_id="${node_id//-/_}"
+fi
+
+if [ -n "$disable_core_dumps" ]
+then
+    ulimit -c 0
+fi
+
+trap save_coredumps EXIT
+
+export PGAPPNAME="${node_id:-$HOSTNAME}"
+
+# Set custom poll interval
+if [ -n "$ethereum_polling_interval" ]; then
+    export ETHEREUM_POLLING_INTERVAL=$ethereum_polling_interval
+fi
+
+case "${node_role:-combined-node}" in
+    query-node)
+        start_query_node
+        ;;
+    index-node)
+        start_index_node
+        ;;
+    combined-node)
+        start_combined_node
+        ;;
+    *)
+        echo "Unknown mode for start-node: $1"
+        echo "usage: start (combined-node|query-node|index-node)"
+        exit 1
+esac

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "create:matchain": "graph create open-format-matchain --node http://127.0.0.1:8020",
     "create:openformat": "graph create open-format-openformat --node http://127.0.0.1:8020",
     "create-mobula:matchain": "dotenv cross-var -- graph create open-format-matchain-%MOBULA_VERSION% --node http://20.84.160.190:8020",
+    "create:fly-openformat": "dotenv cross-var -- graph create open-format-openformat --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
+    "create:fly-turbo": "dotenv cross-var -- graph create open-format-turbo --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
 
     "gen:polygon": "graph codegen subgraph.polygon.yaml",
     "gen:base-sepolia": "graph codegen subgraph.base-sepolia.yaml",
@@ -51,6 +53,8 @@
     "deploy:turbo": "graph deploy open-format-local --ipfs https://ipfs.satsuma.xyz --node http://127.0.0.1:8020 subgraph.turbo.yaml",
     "deploy:matchain": "graph deploy open-format-matchain --ipfs https://ipfs.satsuma.xyz --node http://127.0.0.1:8020 subgraph.matchain.yaml",
     "deploy:openformat": "graph deploy open-format-openformat --ipfs https://ipfs.satsuma.xyz --node http://127.0.0.1:8020 subgraph.openformat.yaml",
+    "deploy:fly-openformat": "dotenv cross-var -- graph deploy open-format-openformat --ipfs https://ipfs.satsuma.xyz --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% subgraph.openformat.yaml",
+    "deploy:fly-turbo": "dotenv cross-var -- graph deploy open-format-turbo --ipfs https://ipfs.satsuma.xyz --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% subgraph.turbo.yaml",
 
     "remove:aurora-testnet": "dotenv cross-var -- graph remove --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% open-format/aurora-testnet",
 


### PR DESCRIPTION
## Description

This PR changes the deployment of subgraphs to Fly.io from multiple servers (one for each chain) to a single server that indexes all chains.

Changes:

- Created a new `openformat-deployer-staging` app that authenticates create/deploy subgraphs requests and proxies them to the graph-node server. Currently uses creadentials: user: `admin`, password: env variable `PASSWORD`
- Created single graph-node server `openformat-graph-node-staging` that will index all chains.
- Changed graph-node config from environment variables to configuration file. Right now only `turbo` and `openformat` chains are configured.
- Added new deploy commands for turbo and openformat chains.