### PR TITLE
fix: Use increase in non-reset metrics in Alerts

### DIFF
--- a/env/openformat-graph-node-grafana/provisioning/alerting/alert-rules.yaml
+++ b/env/openformat-graph-node-grafana/provisioning/alerting/alert-rules.yaml
@@ -78,7 +78,7 @@ groups:
                     uid: PBFA97CFB590B2093
                 disableTextWrap: false
                 editorMode: builder
-                expr: store_connection_error_count
+                expr: increase(store_connection_error_count[1m])
                 fullMetaSearch: false
                 hide: false
                 includeNullMetadata: true
@@ -194,7 +194,7 @@ groups:
                     uid: PBFA97CFB590B2093
                 disableTextWrap: false
                 editorMode: builder
-                expr: polling_monitor_errors
+                expr: increase(polling_monitor_errors[1m])
                 fullMetaSearch: false
                 hide: false
                 includeNullMetadata: true


### PR DESCRIPTION
## Description

This PR fixes the condition for some Alert that use counter metrics that are not reset. Without this fix those alerts will continue to fire event when the problem has been solved.

## Type of Change

Please check the boxes that apply to your pull request:

- [X] Bug fix (non-breaking change which fixes an issue)
