### PR TITLE
feat: add Aurora blockchain network support

### DIFF
--- a/env/openformat-graph-node-staging/config.toml
+++ b/env/openformat-graph-node-staging/config.toml
@@ -15,6 +15,11 @@ shard = "primary"
 provider = [
   { label = "turbo", url = "https://rpc-0x4e45415f.aurora-cloud.dev", transport="rpc", features = [ "archive", "traces" ] },
 ]
+[chains.aurora]
+shard = "primary"
+provider = [
+  { label = "aurora", url = "https://mainnet.aurora.dev", transport="rpc", features = [ "archive", "traces" ] },
+]
 
 [deployment]
 [[deployment.rule]]

--- a/env/openformat-graph-node-staging/fly.toml
+++ b/env/openformat-graph-node-staging/fly.toml
@@ -7,7 +7,7 @@ app = 'openformat-graph-node-staging'
 primary_region = 'lhr'
 
 [env]
-  ipfs = "https://ipfs.satsuma.xyz"
+  ipfs = "https://ipfs.network.thegraph.com"
   GRAPH_NODE_CONFIG = "/config.toml"
   GRAPH_LOG = "debug"
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "create-mobula:matchain": "dotenv cross-var -- graph create open-format-matchain-%MOBULA_VERSION% --node http://20.84.160.190:8020",
     "create:fly-openformat": "dotenv cross-var -- graph create open-format-openformat --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
     "create:fly-turbo": "dotenv cross-var -- graph create open-format-turbo --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
+    "create:fly-aurora": "dotenv cross-var -- graph create open-format-aurora --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL%",
 
     "gen:polygon": "graph codegen subgraph.polygon.yaml",
     "gen:base-sepolia": "graph codegen subgraph.base-sepolia.yaml",
@@ -55,6 +56,7 @@
     "deploy:openformat": "graph deploy open-format-openformat --ipfs https://ipfs.satsuma.xyz --node http://127.0.0.1:8020 subgraph.openformat.yaml",
     "deploy:fly-openformat": "dotenv cross-var -- graph deploy open-format-openformat --ipfs https://ipfs.satsuma.xyz --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% subgraph.openformat.yaml",
     "deploy:fly-turbo": "dotenv cross-var -- graph deploy open-format-turbo --ipfs https://ipfs.satsuma.xyz --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% subgraph.turbo.yaml",
+    "deploy:fly-aurora": "dotenv cross-var -- graph deploy open-format-aurora --ipfs https://ipfs.satsuma.xyz --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% subgraph.aurora.yaml",
 
     "remove:aurora-testnet": "dotenv cross-var -- graph remove --node https://admin:%GRAPH_NODE_PASSWORD%@%GRAPH_NODE_URL% open-format/aurora-testnet",
 


### PR DESCRIPTION
## Summary

This pull request adds support for the Aurora blockchain network to the subgraph deployment infrastructure.

## Description

The changes introduce Aurora blockchain network support by:

- Adding Aurora mainnet configuration in the graph-node staging environment config
- Updating the IPFS endpoint from Satsuma to The Graph's network for improved reliability
- Adding npm scripts for Aurora subgraph creation and deployment workflows

These changes enable deploying and managing Open Format subgraphs on the Aurora network, expanding the protocol's blockchain compatibility.

## Type of Change

Please check the boxes that apply to your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to documentation only)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):
